### PR TITLE
공용 체크박스 컴포넌트를 구현한다.

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -10,6 +10,7 @@ const config: StorybookConfig = {
     '@chromatic-com/storybook',
     '@storybook/addon-interactions',
     'storybook-addon-remix-react-router',
+    'storybook-addon-pseudo-states',
   ],
   framework: {
     name: '@storybook/react-webpack5',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "msw-storybook-addon": "^2.0.2",
     "postcss-styled-syntax": "^0.6.4",
     "prettier": "^3.3.2",
+    "storybook-addon-pseudo-states": "^3.1.1",
     "storybook-addon-remix-react-router": "^3.0.0",
     "style-loader": "^4.0.0",
     "stylelint": "^16.6.1",

--- a/frontend/src/components/Checkbox/Checkbox.stories.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Checkbox from '@/components/Checkbox/Checkbox';
+/** hover 및 체크 시 UI가 변하는 간단한 체크박스입니다. */
+const meta: Meta<typeof Checkbox> = {
+  component: Checkbox,
+  parameters: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const UnChecked: Story = {
+  args: { isChecked: false },
+};
+export const Hover: Story = {
+  args: { isChecked: false },
+  parameters: { pseudo: { hover: true } },
+};
+export const Checked: Story = {
+  args: { isChecked: true },
+};

--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,65 @@
+import styled from '@emotion/styled';
+import { MouseEvent, useCallback, useState } from 'react';
+
+interface StyledProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  $width: keyof typeof widthSize;
+  isChecked?: boolean;
+  $color?: 'string';
+}
+const widthSize = { small: '45px', medium: '110px', large: '140px', full: '100%' };
+
+const S = {
+  Checkbox: styled.label<{ isChecked: boolean }>`
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+    border: 3px solid ${({ theme }) => theme.palette.grey200};
+    border-radius: 3px;
+    &:hover {
+      border-color: ${({ theme }) => theme.palette.grey500};
+    }
+    ${({ isChecked, theme }) => (isChecked ? `&&{ border-color:${theme.palette.green500}; }` : '')}
+  `,
+  CheckboxInput: styled.input`
+    opacity: 0;
+    position: absolute;
+    cursor: pointer;
+  `,
+
+  CheckMark: styled.span<{ isChecked: boolean }>`
+    width: 20px;
+    height: 20px;
+    display: flex;
+    cursor: pointer;
+    justify-content: center;
+
+    ${({ isChecked, theme }) =>
+      isChecked
+        ? ` &::after {
+          content: '✔';
+          color: white;
+        }
+        background-color:${theme.palette.green500};
+        `
+        : ''}
+  `,
+};
+
+const Checkbox = ({ isChecked = false, $width, ...rest }: StyledProps) => {
+  const [isCheckedState, setIsCheckedState] = useState<boolean>(isChecked);
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLInputElement>) => {
+      setIsCheckedState(!isCheckedState);
+    },
+    [isCheckedState],
+  );
+  return (
+    <S.Checkbox isChecked={isCheckedState}>
+      <S.CheckboxInput onClick={handleClick} />
+      <S.CheckMark isChecked={isCheckedState} />
+    </S.Checkbox>
+  );
+};
+
+export default Checkbox;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10640,6 +10640,11 @@ statuses@2.0.1, statuses@^2.0.1:
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
+storybook-addon-pseudo-states@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-3.1.1.tgz#4bbdb995ed636586ba744df37abab036158b2401"
+  integrity sha512-08JNTfsiSfj0GgNV4q6+v6iU+Acp7ib/MdySPDb8p+C8N/e+kf6lnM7kIiE/GnTPXlg3dfV6FMaWgGYVfdTcLw==
+
 storybook-addon-remix-react-router@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/storybook-addon-remix-react-router/-/storybook-addon-remix-react-router-3.0.0.tgz#e31e3b1ba51481de7c3daaac9f43f72e9c4f00bc"


### PR DESCRIPTION
## ❗ Issue

- #40 

## ✨ 구현한 기능
- 체크박스 기능 구현
- hover 스토리 작성을 위해 'storybook-addon-pseudo-states' addon 의존성 추가
## 📢 논의하고 싶은 내용


## 🎸 기타
- input 태그에 체크박스속성으로 구현하면 내부체크박스 색상이 파랑으로 고정이며, 브라우저마다 색상이 달라
- 클릭은 input 태그로 다루고 표시는 span태그에 리액트 컴포넌트에 특수문자 v를 넣어 구현하였습니다.

- hover 스토리 작성을 위해 'storybook-addon-pseudo-states' addon 의존성 추가 하였습니다.
