### PR TITLE
Footer와 Header 공통 컴포넌트의 icon에 Link, navigator를 추가한다.

### DIFF
--- a/frontend/src/components/common/Footer/Footer.tsx
+++ b/frontend/src/components/common/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
-import { useMatch } from 'react-router-dom';
+import { Link, LinkProps, useMatch } from 'react-router-dom';
 
 import {
   ChecklistLogo,
@@ -53,15 +53,24 @@ const S = {
     font-size: ${({ theme }) => theme.text.size.medium};
   `,
 };
+type MakeOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+const linkDecorator = (Logo: React.FC, path: string) => {
+  const LogoLinked = (props: MakeOptional<LinkProps, 'to'>) => (
+    <Link to={path} {...props}>
+      <Logo />
+    </Link>
+  );
+  return LogoLinked;
+};
 
 const Footer = Object.assign(FooterWrapper, {
-  HomeLogo,
-  LocationLogo,
-  ChecklistLogo,
-  MyPageLogo,
-  HomeLogoActive,
-  LocationLogoActive,
-  ChecklistLogoActive,
-  MyPageLogoActive,
+  HomeLogo: linkDecorator(HomeLogo, '/'),
+  LocationLogo: linkDecorator(LocationLogo, '/location'),
+  ChecklistLogo: linkDecorator(ChecklistLogo, '/checklist-list'),
+  MyPageLogo: linkDecorator(MyPageLogo, '/mypage'),
+  HomeLogoActive: linkDecorator(HomeLogoActive, '/'),
+  LocationLogoActive: linkDecorator(LocationLogoActive, '/location'),
+  ChecklistLogoActive: linkDecorator(ChecklistLogoActive, '/checklist-list'),
+  MyPageLogoActive: linkDecorator(MyPageLogoActive, '/mypage'),
 });
 export default Footer;

--- a/frontend/src/components/common/Footer/Footer.tsx
+++ b/frontend/src/components/common/Footer/Footer.tsx
@@ -54,7 +54,7 @@ const S = {
   `,
 };
 type MakeOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
-const linkDecorator = (Logo: React.FC, path: string) => {
+export const linkDecorator = (Logo: React.FC, path: string) => {
   const LogoLinked = (props: MakeOptional<LinkProps, 'to'>) => (
     <Link to={path} {...props}>
       <Logo />

--- a/frontend/src/components/common/Header/Header.tsx
+++ b/frontend/src/components/common/Header/Header.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import ArrowBack from '@/assets/arrow-back.svg';
 import Logo from '@/assets/logo.svg';
+import { linkDecorator } from '@/components/common/Footer/Footer';
 import { title3 } from '@/styles/common';
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
@@ -66,21 +68,20 @@ const S = {
 };
 
 const Header = Object.assign(HeaderWrapper, {
-  Logo: () => (
-    <Logo
-      style={{
-        cursor: 'pointer',
-      }}
-    />
-  ),
-  Backward: (props: React.SVGProps<SVGSVGElement>) => (
-    <ArrowBack
-      style={{
-        cursor: 'pointer',
-      }}
-      {...props}
-    />
-  ),
+  Logo: linkDecorator(Logo, '/'),
+  Backward: (props: React.SVGProps<SVGSVGElement>) => {
+    const navigate = useNavigate();
+    const handleClick = () => navigate(-1);
+    return (
+      <ArrowBack
+        style={{
+          cursor: 'pointer',
+        }}
+        onClick={handleClick}
+        {...props}
+      />
+    );
+  },
   TextButton: S.TextButton,
   Text: S.Text,
 });


### PR DESCRIPTION
## ❗ Issue

- #113 

## ✨ 구현한 기능

직접 클릭해본결과 페이지 이동됩니다.
( 사진은 직접해본결과 되었다는 의미로 올린거니 대충 보셔도됨)
![스크린샷 2024-07-25 175229](https://github.com/user-attachments/assets/c50ad121-f026-464f-9697-e4abe1055116)
![스크린샷 2024-07-25 175232](https://github.com/user-attachments/assets/c32f273b-e5ad-4651-91dd-d87fdb44db61)
![스크린샷 2024-07-25 180031](https://github.com/user-attachments/assets/3783c928-b977-4914-a13d-d9774e565ea9)
![스크린샷 2024-07-25 180033](https://github.com/user-attachments/assets/60b7b4c8-f6de-4721-82f6-af758114e2ad)

스토리북에서는 Link를 추가함에 따라 클릭시 에러페이지로 이동.
당연히 이렇게될거라 예상은했지만, 
라우터넣어도 별문제없는 스토리도 있길래 추후 해결가능해보임
## 📢 논의하고 싶은 내용



## 🎸 기타

