### PR TITLE
배포 서버의 로그가 기록되지 않는 문제를 해결한다.

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -65,4 +65,4 @@ jobs:
         run: sudo fuser -k -n tcp 8080 || true
 
       - name: Start server
-        run: sudo nohup java -jar ./backend/bang-ggood/build/libs/*SNAPSHOT.jar &
+        run: sudo nohup java -jar ./backend/bang-ggood/build/libs/*SNAPSHOT.jar > /home/ubuntu/actions-runner/server.log 2>&1 &


### PR DESCRIPTION
## ❗ Issue
-  #117 

## ✨ 구현한 기능
- cd 스크립트에 배포 시 로그 파일을 지정해주었다.

## 📢 논의하고 싶은 내용


## 🎸 기타

