### PR TITLE
[FE] 탭을 변경된 디자인으로 리팩토링한다. 

### DIFF
--- a/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestion.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestion.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+//TODO: indicator 컴포넌트화 필요
 import { QuestionDot } from '@/assets/assets';
 import FaceMark from '@/components/common/FaceMark/FaceMark';
 import { addAnswerProps } from '@/pages/ChecklistSummaryPage';
@@ -20,11 +21,13 @@ export const emotionPhrase: Record<Emotion, string> = {
 };
 
 const ChecklistQuestion = ({ question, addAnswer, deleteAnswer, questionSelectedAnswer }: Props) => {
+  const { questionId } = question;
+
   const handleClick = (newAnswer: number) => {
-    if (questionSelectedAnswer(question.questionId) === newAnswer) {
-      deleteAnswer(question.questionId);
+    if (questionSelectedAnswer(questionId) === newAnswer) {
+      deleteAnswer(questionId);
     } else {
-      addAnswer({ questionId: question.questionId, newAnswer });
+      addAnswer({ questionId: questionId, newAnswer });
     }
   };
 
@@ -51,7 +54,7 @@ const ChecklistQuestion = ({ question, addAnswer, deleteAnswer, questionSelected
           const { name: emotionName, id } = emotion;
           return (
             <FaceMark onClick={() => handleClick(id)} key={id}>
-              <FaceMark.FaceIcon emotion={emotionName} isFilled={questionSelectedAnswer(question.questionId) === id} />
+              <FaceMark.FaceIcon emotion={emotionName} isFilled={questionSelectedAnswer(questionId) === id} />
               <FaceMark.Footer>{emotionPhrase[emotionName]}</FaceMark.Footer>
             </FaceMark>
           );

--- a/frontend/src/components/NewChecklist/OptionModal/OptionModal.tsx
+++ b/frontend/src/components/NewChecklist/OptionModal/OptionModal.tsx
@@ -11,9 +11,9 @@ export const totalOptionCount = 14;
 
 interface Props {
   isOpen: boolean;
-  setIsOpen: React.Dispatch<boolean>;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   selectedOptions: number[];
-  setSelectedOptions: React.Dispatch<number[]>;
+  setSelectedOptions: React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 const OptionModal = ({ isOpen, setIsOpen, selectedOptions, setSelectedOptions }: Props) => {

--- a/frontend/src/components/NewChecklist/OptionModal/OptionModalInfoBox.tsx
+++ b/frontend/src/components/NewChecklist/OptionModal/OptionModalInfoBox.tsx
@@ -9,8 +9,9 @@ import theme from '@/styles/theme';
 
 interface Props {
   selectedOptions: number[];
-  setSelectedOptions: React.Dispatch<number[]>;
+  setSelectedOptions: React.Dispatch<React.SetStateAction<number[]>>;
 }
+
 const OptionModalInfoBox = ({ selectedOptions, setSelectedOptions }: Props) => {
   const allOptions = new Array(totalOptionCount).fill(0).map((e, i) => i + 1);
   const { onClickSelectAllOptions, isAllSelected, setIsAllSelected } = useAllSelect({

--- a/frontend/src/components/common/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/common/Checkbox/Checkbox.tsx
@@ -7,7 +7,7 @@ import theme from '@/styles/theme';
 
 interface StyledProps extends React.InputHTMLAttributes<HTMLInputElement> {
   isChecked: boolean;
-  setIsChecked: React.Dispatch<boolean>;
+  setIsChecked: React.Dispatch<React.SetStateAction<boolean>>;
   color?: string;
   hoverBorderColor?: string;
   onClick: () => void;

--- a/frontend/src/components/common/Tabs/TabContext.tsx
+++ b/frontend/src/components/common/Tabs/TabContext.tsx
@@ -1,15 +1,13 @@
 import { createContext, ReactNode, useContext, useState } from 'react';
 
-import { Tab } from '@/components/common/Tabs/Tabs';
-
 interface ContextProps {
   currentTabId: number;
   setCurrentTabId: React.Dispatch<React.SetStateAction<number>>;
 }
 const TabContext = createContext<ContextProps>(null);
 
-export const TabProvider = ({ children, tabList }: { children: ReactNode; tabList: Tab[] }) => {
-  const [currentTabId, setCurrentTabId] = useState<number>(tabList[0].id);
+export const TabProvider = ({ children }: { children: ReactNode }) => {
+  const [currentTabId, setCurrentTabId] = useState<number>(0);
 
   return <TabContext.Provider value={{ currentTabId, setCurrentTabId }}>{children}</TabContext.Provider>;
 };

--- a/frontend/src/components/common/Tabs/TabContext.tsx
+++ b/frontend/src/components/common/Tabs/TabContext.tsx
@@ -1,13 +1,15 @@
 import { createContext, ReactNode, useContext, useState } from 'react';
 
+import { Tab } from '@/components/common/Tabs/Tabs';
+
 interface ContextProps {
-  currentTabId: string;
-  setCurrentTabId: React.Dispatch<React.SetStateAction<string>>;
+  currentTabId: number;
+  setCurrentTabId: React.Dispatch<React.SetStateAction<number>>;
 }
 const TabContext = createContext<ContextProps>(null);
 
-export const TabProvider = ({ children }: { children: ReactNode }) => {
-  const [currentTabId, setCurrentTabId] = useState<string>(null);
+export const TabProvider = ({ children, tabList }: { children: ReactNode; tabList: Tab[] }) => {
+  const [currentTabId, setCurrentTabId] = useState<number>(tabList[0].id);
 
   return <TabContext.Provider value={{ currentTabId, setCurrentTabId }}>{children}</TabContext.Provider>;
 };

--- a/frontend/src/components/common/Tabs/TabContext.tsx
+++ b/frontend/src/components/common/Tabs/TabContext.tsx
@@ -1,0 +1,21 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+interface ContextProps {
+  currentTabId: string;
+  setCurrentTabId;
+}
+const TabContext = createContext<ContextProps>(null);
+
+export const TabProvider = ({ children }: { children: ReactNode }) => {
+  const [currentTabId, setCurrentTabId] = useState<string>(null);
+
+  return <TabContext.Provider value={{ currentTabId, setCurrentTabId }}>{children}</TabContext.Provider>;
+};
+
+export const useTabContext = () => {
+  const context = useContext(TabContext);
+  if (!context) {
+    throw new Error('useAccordionContext는 AccordionProvider에서 사용해야 합니다.');
+  }
+  return context;
+};

--- a/frontend/src/components/common/Tabs/TabContext.tsx
+++ b/frontend/src/components/common/Tabs/TabContext.tsx
@@ -2,7 +2,7 @@ import { createContext, ReactNode, useContext, useState } from 'react';
 
 interface ContextProps {
   currentTabId: string;
-  setCurrentTabId;
+  setCurrentTabId: React.Dispatch<React.SetStateAction<string>>;
 }
 const TabContext = createContext<ContextProps>(null);
 
@@ -15,7 +15,7 @@ export const TabProvider = ({ children }: { children: ReactNode }) => {
 export const useTabContext = () => {
   const context = useContext(TabContext);
   if (!context) {
-    throw new Error('useAccordionContext는 AccordionProvider에서 사용해야 합니다.');
+    throw new Error('useTabContext는 TabProvider 안에서 사용해야 합니다.');
   }
   return context;
 };

--- a/frontend/src/components/common/Tabs/Tabs.stories.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import Tabs, { Menu } from '@/components/common/Tabs/Tabs';
+import Tabs, { Tab } from '@/components/common/Tabs/Tabs';
 
 const meta = {
   title: 'components/Tabs',
@@ -17,25 +17,26 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const mockMenuList: Menu[] = [
+const mockMenuList: Tab[] = [
   {
     name: '기본 정보',
     id: 'basic-info',
+    content: <div>basic-info</div>,
   },
   {
     name: '체크리스트',
     id: 'checklist',
+    content: <div>checklist</div>,
   },
   {
     name: '메모 및 사진',
     id: 'extra-info',
+    content: <div>extra-info</div>,
   },
 ];
 
 export const Default: Story = {
   args: {
-    menuList: mockMenuList,
-    onMoveMenu: () => {},
-    currentMenuId: 'basic-info',
+    tabList: mockMenuList,
   },
 };

--- a/frontend/src/components/common/Tabs/Tabs.stories.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
   },
   decorators: [
     Story => (
-      <TabProvider tabList={mockMenuList}>
+      <TabProvider>
         <Story />
       </TabProvider>
     ),

--- a/frontend/src/components/common/Tabs/Tabs.stories.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { TabProvider } from '@/components/common/Tabs/TabContext';
 import Tabs, { Tab } from '@/components/common/Tabs/Tabs';
+
+import mobileDecorator from '../../../../.storybook/common';
 
 const meta = {
   title: 'components/Tabs',
@@ -12,23 +15,48 @@ const meta = {
       },
     },
   },
+  decorators: [
+    Story => (
+      <TabProvider tabList={mockMenuList}>
+        <Story />
+      </TabProvider>
+    ),
+    mobileDecorator,
+  ],
 } satisfies Meta<typeof Tabs>;
+
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
 const mockMenuList: Tab[] = [
   {
-    name: '기본 정보',
-    id: 'basic-info',
+    id: 1,
+    name: '청결',
   },
   {
-    name: '체크리스트',
-    id: 'checklist',
+    id: 2,
+    name: '방 컨디션',
   },
   {
-    name: '메모 및 사진',
-    id: 'extra-info',
+    id: 3,
+    name: '편의시설',
+  },
+  {
+    id: 4,
+    name: '옵션',
+  },
+  {
+    id: 5,
+    name: '주거환경',
+  },
+  {
+    id: 6,
+    name: '보안',
+  },
+  {
+    id: 7,
+    name: '경제적',
   },
 ];
 

--- a/frontend/src/components/common/Tabs/Tabs.stories.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.stories.tsx
@@ -21,17 +21,14 @@ const mockMenuList: Tab[] = [
   {
     name: '기본 정보',
     id: 'basic-info',
-    content: <div>basic-info</div>,
   },
   {
     name: '체크리스트',
     id: 'checklist',
-    content: <div>checklist</div>,
   },
   {
     name: '메모 및 사진',
     id: 'extra-info',
-    content: <div>extra-info</div>,
   },
 ];
 

--- a/frontend/src/components/common/Tabs/Tabs.stories.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { TabProvider } from '@/components/common/Tabs/TabContext';
-import Tabs, { TabWithCompletion } from '@/components/common/Tabs/Tabs';
+import Tabs from '@/components/common/Tabs/Tabs';
+import { newChecklistTabs } from '@/constants/tabs';
 
 import mobileDecorator from '../../../../.storybook/common';
 
@@ -29,46 +30,10 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const mockMenuList: TabWithCompletion[] = [
-  {
-    id: 1,
-    name: '청결',
-    isCompleted: true,
-  },
-  {
-    id: 2,
-    name: '방 컨디션',
-    isCompleted: true,
-  },
-  {
-    id: 3,
-    name: '편의시설',
-    isCompleted: true,
-  },
-  {
-    id: 4,
-    name: '옵션',
-    isCompleted: true,
-  },
-  {
-    id: 5,
-    name: '주거환경',
-    isCompleted: false,
-  },
-  {
-    id: 6,
-    name: '보안',
-    isCompleted: false,
-  },
-  {
-    id: 7,
-    name: '경제적',
-    isCompleted: false,
-  },
-];
+const mockTabsWithCompletion = newChecklistTabs.map(tab => ({ ...tab, isCompleted: true }));
 
 export const Default: Story = {
   args: {
-    tabList: mockMenuList,
+    tabList: mockTabsWithCompletion,
   },
 };

--- a/frontend/src/components/common/Tabs/Tabs.stories.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { TabProvider } from '@/components/common/Tabs/TabContext';
-import Tabs, { Tab } from '@/components/common/Tabs/Tabs';
+import Tabs, { TabWithCompletion } from '@/components/common/Tabs/Tabs';
 
 import mobileDecorator from '../../../../.storybook/common';
 
@@ -29,34 +29,41 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const mockMenuList: Tab[] = [
+const mockMenuList: TabWithCompletion[] = [
   {
     id: 1,
     name: '청결',
+    isCompleted: true,
   },
   {
     id: 2,
     name: '방 컨디션',
+    isCompleted: true,
   },
   {
     id: 3,
     name: '편의시설',
+    isCompleted: true,
   },
   {
     id: 4,
     name: '옵션',
+    isCompleted: true,
   },
   {
     id: 5,
     name: '주거환경',
+    isCompleted: false,
   },
   {
     id: 6,
     name: '보안',
+    isCompleted: false,
   },
   {
     id: 7,
     name: '경제적',
+    isCompleted: false,
   },
 ];
 

--- a/frontend/src/components/common/Tabs/Tabs.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.tsx
@@ -64,6 +64,7 @@ const Tab = styled.div<{ active: boolean }>`
     active ? `3px solid ${theme.palette.yellow400}` : `3px solid ${theme.palette.yellow100}`};
 
   &:hover {
-    background-color: ${({ theme, active }) => (active ? theme.palette.yellow400 : '#ddd')};
+    background-color: ${({ theme }) => theme.palette.yellow200};
+    border-radius: 5px;
   }
 `;

--- a/frontend/src/components/common/Tabs/Tabs.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.tsx
@@ -1,61 +1,76 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import { flexCenter } from '@/styles/common';
 
 interface Props {
-  menuList: Menu[];
-  onMoveMenu: (menu: string) => void;
-  currentMenuId: string;
+  tabList: Tab[];
 }
 
-export type Menu = {
+export type Tab = {
   name: string;
   id: string;
+  content: React.ReactNode;
 };
 
-const Tabs = ({ menuList, onMoveMenu, currentMenuId }: Props) => {
+const Tabs = ({ tabList }: Props) => {
+  const [currentTabId, setCurrentTabId] = useState(tabList[0].id);
+
+  const renderContent = () => {
+    const targetTab = tabList.filter(tab => tab.id === currentTabId)[0];
+    if (!targetTab) throw new Error('해당 탭이 존재하지 않습니다.');
+    return targetTab.content;
+  };
+
+  const onMoveTab = (tabId: string) => {
+    setCurrentTabId(tabId);
+  };
+
   return (
-    <S.Container>
-      <S.FlexContainer>
-        {menuList?.map((menu, index) => {
-          return (
-            <S.OneMenu
-              menuCount={menuList.length}
-              key={index}
-              onClick={() => onMoveMenu(menu.id)}
-              selected={menu.id === currentMenuId}
-            >
-              <div>{menu.name}</div>
-            </S.OneMenu>
-          );
-        })}
-      </S.FlexContainer>
-    </S.Container>
+    <Container>
+      <FlexContainer>
+        {tabList?.map(tab => (
+          <Tab key={tab.id} onClick={() => onMoveTab(tab.id)} active={tab.id === currentTabId}>
+            {tab.name}
+          </Tab>
+        ))}
+      </FlexContainer>
+    </Container>
   );
 };
 
 export default Tabs;
 
-export const S = {
-  Container: styled.div`
-    display: flex;
-    position: relative;
-    width: 100%;
-    height: 60px;
+const Container = styled.div`
+  width: 100%;
+  overflow-x: auto;
 
-    flex-direction: column;
-  `,
-  FlexContainer: styled.div`
-    display: flex;
-  `,
-  OneMenu: styled.div<{ selected?: boolean; menuCount: number }>`
-    width: ${({ menuCount }) => `calc(100% / ${menuCount})`};
-    height: 60px;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
 
-    ${flexCenter}
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
 
-    font-weight: ${({ selected, theme }) => (selected ? theme.text.weight.bold : theme.text.weight.medium)};
-    border-bottom: ${({ selected, theme }) =>
-      selected ? `3px solid ${theme.palette.yellow400}` : `3px solid ${theme.palette.yellow100}`};
-  `,
-};
+const FlexContainer = styled.div`
+  display: inline-flex;
+`;
+
+const Tab = styled.div<{ active: boolean }>`
+  display: inline-block;
+  z-index: ${({ theme }) => theme.zIndex.TABS} ${flexCenter};
+  margin-right: 10px;
+  padding: 10px 20px;
+
+  color: ${({ theme, active }) => (active ? theme.palette.yellow600 : theme.palette.black)};
+  font-weight: ${({ active, theme }) => (active ? theme.text.weight.bold : theme.text.weight.medium)};
+  cursor: pointer;
+  border-bottom: ${({ active, theme }) =>
+    active ? `3px solid ${theme.palette.yellow400}` : `3px solid ${theme.palette.yellow100}`};
+
+  &:hover {
+    background-color: ${({ theme, active }) => (active ? theme.palette.yellow400 : '#ddd')};
+  }
+`;

--- a/frontend/src/components/common/Tabs/Tabs.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.tsx
@@ -2,18 +2,10 @@ import styled from '@emotion/styled';
 
 import { useTabContext } from '@/components/common/Tabs/TabContext';
 import { flexCenter } from '@/styles/common';
+import { TabWithCompletion } from '@/types/tab';
 
 interface Props {
   tabList: TabWithCompletion[];
-}
-
-export interface Tab {
-  name: string;
-  id: number;
-}
-
-export interface TabWithCompletion extends Tab {
-  isCompleted: boolean;
 }
 
 const Tabs = ({ tabList }: Props) => {
@@ -61,7 +53,8 @@ const FlexContainer = styled.div`
 
 const Tab = styled.div<{ active: boolean }>`
   position: relative;
-  z-index: ${({ theme }) => theme.zIndex.TABS} ${flexCenter};
+  z-index: ${({ theme }) => theme.zIndex.TABS};
+  ${flexCenter};
   margin-top: 10px;
   margin-right: 6px;
   padding: 10px 16px;

--- a/frontend/src/components/common/Tabs/Tabs.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 
+import { useTabContext } from '@/components/common/Tabs/TabContext';
 import { flexCenter } from '@/styles/common';
 
 interface Props {
@@ -10,17 +10,10 @@ interface Props {
 export type Tab = {
   name: string;
   id: string;
-  content: React.ReactNode;
 };
 
 const Tabs = ({ tabList }: Props) => {
-  const [currentTabId, setCurrentTabId] = useState(tabList[0].id);
-
-  const renderContent = () => {
-    const targetTab = tabList.filter(tab => tab.id === currentTabId)[0];
-    if (!targetTab) throw new Error('해당 탭이 존재하지 않습니다.');
-    return targetTab.content;
-  };
+  const { currentTabId, setCurrentTabId } = useTabContext();
 
   const onMoveTab = (tabId: string) => {
     setCurrentTabId(tabId);

--- a/frontend/src/components/common/Tabs/Tabs.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.tsx
@@ -9,13 +9,13 @@ interface Props {
 
 export type Tab = {
   name: string;
-  id: string;
+  id: number;
 };
 
 const Tabs = ({ tabList }: Props) => {
   const { currentTabId, setCurrentTabId } = useTabContext();
 
-  const onMoveTab = (tabId: string) => {
+  const onMoveTab = (tabId: number) => {
     setCurrentTabId(tabId);
   };
 

--- a/frontend/src/components/common/Tabs/Tabs.tsx
+++ b/frontend/src/components/common/Tabs/Tabs.tsx
@@ -4,13 +4,17 @@ import { useTabContext } from '@/components/common/Tabs/TabContext';
 import { flexCenter } from '@/styles/common';
 
 interface Props {
-  tabList: Tab[];
+  tabList: TabWithCompletion[];
 }
 
-export type Tab = {
+export interface Tab {
   name: string;
   id: number;
-};
+}
+
+export interface TabWithCompletion extends Tab {
+  isCompleted: boolean;
+}
 
 const Tabs = ({ tabList }: Props) => {
   const { currentTabId, setCurrentTabId } = useTabContext();
@@ -22,11 +26,15 @@ const Tabs = ({ tabList }: Props) => {
   return (
     <Container>
       <FlexContainer>
-        {tabList?.map(tab => (
-          <Tab key={tab.id} onClick={() => onMoveTab(tab.id)} active={tab.id === currentTabId}>
-            {tab.name}
-          </Tab>
-        ))}
+        {tabList?.map(tab => {
+          const { isCompleted, id, name } = tab;
+          return (
+            <Tab key={id} onClick={() => onMoveTab(tab.id)} active={tab.id === currentTabId}>
+              {name}
+              {!isCompleted && <UncompletedIndicator />}
+            </Tab>
+          );
+        })}
       </FlexContainer>
     </Container>
   );
@@ -52,19 +60,27 @@ const FlexContainer = styled.div`
 `;
 
 const Tab = styled.div<{ active: boolean }>`
-  display: inline-block;
+  position: relative;
   z-index: ${({ theme }) => theme.zIndex.TABS} ${flexCenter};
-  margin-right: 10px;
-  padding: 10px 20px;
+  margin-top: 10px;
+  margin-right: 6px;
+  padding: 10px 16px;
 
   color: ${({ theme, active }) => (active ? theme.palette.yellow600 : theme.palette.black)};
   font-weight: ${({ active, theme }) => (active ? theme.text.weight.bold : theme.text.weight.medium)};
   cursor: pointer;
   border-bottom: ${({ active, theme }) =>
     active ? `3px solid ${theme.palette.yellow400}` : `3px solid ${theme.palette.yellow100}`};
+`;
 
-  &:hover {
-    background-color: ${({ theme }) => theme.palette.yellow200};
-    border-radius: 5px;
-  }
+const UncompletedIndicator = styled.div`
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 5px;
+  height: 5px;
+  margin-left: 8px;
+
+  background-color: ${({ theme }) => theme.palette.grey400};
+  border-radius: 50%;
 `;

--- a/frontend/src/constants/tabs.ts
+++ b/frontend/src/constants/tabs.ts
@@ -1,4 +1,4 @@
-import { Tab } from '@/components/common/Tabs/Tabs';
+import { Tab } from '@/types/tab';
 
 export const newChecklistTabs: Tab[] = [
   { id: 0, name: '기본 정보' },

--- a/frontend/src/constants/tabs.ts
+++ b/frontend/src/constants/tabs.ts
@@ -1,0 +1,33 @@
+import { Tab } from '@/components/common/Tabs/Tabs';
+
+export const newChecklistTabs: Tab[] = [
+  { id: 0, name: '기본 정보' },
+  {
+    id: 1,
+    name: '청결',
+  },
+  {
+    id: 2,
+    name: '방 컨디션',
+  },
+  {
+    id: 3,
+    name: '편의시설',
+  },
+  {
+    id: 4,
+    name: '옵션',
+  },
+  {
+    id: 5,
+    name: '주거환경',
+  },
+  {
+    id: 6,
+    name: '보안',
+  },
+  {
+    id: 7,
+    name: '경제적',
+  },
+];

--- a/frontend/src/hooks/useAllSelect.ts
+++ b/frontend/src/hooks/useAllSelect.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 interface Props {
   allOptions: (number | string)[];
-  setSelectedOptions: React.Dispatch<(number | string)[]>;
+  setSelectedOptions: React.Dispatch<React.SetStateAction<(number | string)[]>>;
   selectedOptions: (number | string)[];
 }
 

--- a/frontend/src/hooks/useChecklistAnswer.ts
+++ b/frontend/src/hooks/useChecklistAnswer.ts
@@ -33,6 +33,19 @@ const useChecklistAnswer = () => {
     });
   };
 
+  //TODO: 체크리스트 인디케이터를 위한 로직 필요
+  // const [tabWithCompletion, setTabWithCompletion] = useState(
+  //   newChecklistTabs.map(tab => ({ ...tab, isCompleted: false })),
+  // );
+
+  // const changeAnswerCompletion = (targetId: number) => {
+  //   const target = tabWithCompletion.filter(tab => tab.id === targetId);
+  //   return target;
+  // };
+
+  // const checklistQuestionsCount = checklistQuestions.map(category => category.);
+  // const [isCompleteAnswer, setIsCompleteAnswer] = useState<boolean[]>(new Array(newChecklistTabs.length).fill(false));
+
   return { addAnswer, deleteAnswer, questionSelectedAnswer, checklistAnswers };
 };
 

--- a/frontend/src/pages/NewChecklistPage/NewChecklistBody.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistBody.tsx
@@ -22,7 +22,7 @@ interface Props {
   questionSelectedAnswer: (questionId: number) => number | undefined;
 }
 
-const NewChecklistTabContainer = (props: Props) => {
+const NewChecklistBody = (props: Props) => {
   const {
     categoryTabs,
     roomInfo,
@@ -51,7 +51,7 @@ const NewChecklistTabContainer = (props: Props) => {
 
   const renderTabContent = () => {
     switch (currentTabId) {
-      case 0:
+      case 0: //기본 정보
         return (
           <NewChecklistInfoTemplate
             roomInfo={roomInfo}
@@ -61,6 +61,12 @@ const NewChecklistTabContainer = (props: Props) => {
           />
         );
       case 1: //청결
+      case 2: //방 컨디션
+      case 3: //편의시설
+      case 4: //옵션
+      case 5: //주거 환경
+      case 6: //보안
+      case 7: //경제적
         return (
           <NewChecklistTemplate
             checklistQuestions={findQuestions(currentTabId)}
@@ -69,6 +75,7 @@ const NewChecklistTabContainer = (props: Props) => {
             questionSelectedAnswer={questionSelectedAnswer}
           />
         );
+
       default:
         return <div>콘텐츠가 없습니다.</div>;
     }
@@ -76,9 +83,9 @@ const NewChecklistTabContainer = (props: Props) => {
   return (
     <div>
       <Tabs tabList={categoryTabs} />
-      {currentTabId && renderTabContent()}
+      {currentTabId !== null && currentTabId !== undefined && renderTabContent()}
     </div>
   );
 };
 
-export default NewChecklistTabContainer;
+export default NewChecklistBody;

--- a/frontend/src/pages/NewChecklistPage/NewChecklistBody.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistBody.tsx
@@ -6,13 +6,11 @@ import Tabs, { Tab } from '@/components/common/Tabs/Tabs';
 import { addAnswerProps } from '@/pages/ChecklistSummaryPage';
 import NewChecklistInfoTemplate from '@/pages/NewChecklistPage/NewChecklistInfoTemplate';
 import NewChecklistTemplate from '@/pages/NewChecklistPage/NewChecklistTemplate';
-import { ChecklistCategoryQuestions } from '@/types/checklist';
+import { ChecklistCategoryQuestions, ChecklistFormAnswer } from '@/types/checklist';
 import { RoomInfo } from '@/types/room';
 
-export type TemplateType = 'checklist' | 'info';
-
 interface Props {
-  categoryTabs: Tab[];
+  newChecklistTabs: Tab[];
   selectedOptions: number[];
   setSelectedOptions: React.Dispatch<React.SetStateAction<number[]>>;
   roomInfo: RoomInfo;
@@ -20,11 +18,12 @@ interface Props {
   addAnswer: ({ questionId, newAnswer }: addAnswerProps) => void;
   deleteAnswer: (questionId: number) => void;
   questionSelectedAnswer: (questionId: number) => number | undefined;
+  checklistAnswers: ChecklistFormAnswer[];
 }
 
 const NewChecklistBody = (props: Props) => {
   const {
-    categoryTabs,
+    newChecklistTabs,
     roomInfo,
     onChange,
     selectedOptions,
@@ -36,6 +35,9 @@ const NewChecklistBody = (props: Props) => {
   const { currentTabId } = useTabContext();
 
   const [checklistQuestions, setChecklistQuestions] = useState<ChecklistCategoryQuestions[]>([]);
+  //TODO: 체크리스트 인디케이터를 위한 로직 필요
+  // const checklistQuestionsCount = checklistQuestions.map(category => category.questions.length);
+  // const [isCompleteAnswer, setIsCompleteAnswer] = useState<boolean[]>(new Array(newChecklistTabs.length).fill(false));
 
   useEffect(() => {
     const fetchChecklist = async () => {
@@ -45,9 +47,14 @@ const NewChecklistBody = (props: Props) => {
     fetchChecklist();
   }, []);
 
+  //답변 바뀔 때마다 해당 카테고리에 답변이 다 채워졌는지 확인하는 로직
+
   const findQuestions = (targetId: number) => {
     return checklistQuestions.filter(category => category.categoryId === targetId)[0].questions;
   };
+
+  //TODO: 임시 수정 필요
+  const newChecklistTabsWithCompletion = newChecklistTabs.map(tabInfo => ({ ...tabInfo, isCompleted: false }));
 
   const renderTabContent = () => {
     switch (currentTabId) {
@@ -82,7 +89,7 @@ const NewChecklistBody = (props: Props) => {
   };
   return (
     <div>
-      <Tabs tabList={categoryTabs} />
+      <Tabs tabList={newChecklistTabsWithCompletion} />
       {currentTabId !== null && currentTabId !== undefined && renderTabContent()}
     </div>
   );

--- a/frontend/src/pages/NewChecklistPage/NewChecklistBody.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistBody.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 
 import { getChecklistQuestions } from '@/apis/checklist';
 import { useTabContext } from '@/components/common/Tabs/TabContext';
-import Tabs, { Tab } from '@/components/common/Tabs/Tabs';
+import Tabs from '@/components/common/Tabs/Tabs';
 import { addAnswerProps } from '@/pages/ChecklistSummaryPage';
 import NewChecklistInfoTemplate from '@/pages/NewChecklistPage/NewChecklistInfoTemplate';
 import NewChecklistTemplate from '@/pages/NewChecklistPage/NewChecklistTemplate';
 import { ChecklistCategoryQuestions, ChecklistFormAnswer } from '@/types/checklist';
 import { RoomInfo } from '@/types/room';
+import { Tab } from '@/types/tab';
 
 interface Props {
   newChecklistTabs: Tab[];

--- a/frontend/src/pages/NewChecklistPage/NewChecklistBody.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistBody.tsx
@@ -35,9 +35,6 @@ const NewChecklistBody = (props: Props) => {
   const { currentTabId } = useTabContext();
 
   const [checklistQuestions, setChecklistQuestions] = useState<ChecklistCategoryQuestions[]>([]);
-  //TODO: 체크리스트 인디케이터를 위한 로직 필요
-  // const checklistQuestionsCount = checklistQuestions.map(category => category.questions.length);
-  // const [isCompleteAnswer, setIsCompleteAnswer] = useState<boolean[]>(new Array(newChecklistTabs.length).fill(false));
 
   useEffect(() => {
     const fetchChecklist = async () => {

--- a/frontend/src/pages/NewChecklistPage/NewChecklistInfoTemplate.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistInfoTemplate.tsx
@@ -12,7 +12,7 @@ import { RoomInfo, RoomInfoName } from '@/types/room';
 
 interface Props {
   selectedOptions: number[];
-  setSelectedOptions: React.Dispatch<number[]>;
+  setSelectedOptions: React.Dispatch<React.SetStateAction<number[]>>;
   roomInfo: RoomInfo;
   onChange: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }

--- a/frontend/src/pages/NewChecklistPage/NewChecklistInfoTemplate.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistInfoTemplate.tsx
@@ -76,6 +76,7 @@ const NewChecklistInfoTemplate = ({ selectedOptions, setSelectedOptions, roomInf
     </S.ContentWrapper>
   );
 };
+
 const makeCustomForm = (res: MakeFormArgs) => (
   <S.CustomFormField key={res.label}>
     <FormField.Label label={res.label} required={res.required} />

--- a/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
@@ -6,9 +6,9 @@ import { postChecklist } from '@/apis/checklist';
 import Button from '@/components/common/Button/Button';
 import Header from '@/components/common/Header/Header';
 import { TabProvider } from '@/components/common/Tabs/TabContext';
-import { Tab } from '@/components/common/Tabs/Tabs';
 import { useToastContext } from '@/components/common/Toast/ToastContext';
 import { ROUTE_PATH } from '@/constants/routePath';
+import { newChecklistTabs } from '@/constants/tabs';
 import useChecklistAnswer from '@/hooks/useChecklistAnswer';
 import useInputs from '@/hooks/useInput';
 import NewChecklistBody from '@/pages/NewChecklistPage/NewChecklistBody';
@@ -29,38 +29,6 @@ const DefaultRoomInfo: RoomInfo = {
   realEstate: '방끗공인중개사',
 };
 
-export const newChecklistTabs: Tab[] = [
-  { id: 0, name: '기본 정보' },
-  {
-    id: 1,
-    name: '청결',
-  },
-  {
-    id: 2,
-    name: '방 컨디션',
-  },
-  {
-    id: 3,
-    name: '편의시설',
-  },
-  {
-    id: 4,
-    name: '옵션',
-  },
-  {
-    id: 5,
-    name: '주거환경',
-  },
-  {
-    id: 6,
-    name: '보안',
-  },
-  {
-    id: 7,
-    name: '경제적',
-  },
-];
-
 const NewChecklistPage = () => {
   const { showToast } = useToastContext();
 
@@ -71,7 +39,6 @@ const NewChecklistPage = () => {
   const [selectedOptions, setSelectedOptions] = useState<number[]>([]);
 
   /*체크리스트 답변*/
-
   const { addAnswer, deleteAnswer, questionSelectedAnswer, checklistAnswers } = useChecklistAnswer();
 
   const navigate = useNavigate();

--- a/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
@@ -6,6 +6,7 @@ import { postChecklist } from '@/apis/checklist';
 import Button from '@/components/common/Button/Button';
 import Header from '@/components/common/Header/Header';
 import { TabProvider } from '@/components/common/Tabs/TabContext';
+import { Tab } from '@/components/common/Tabs/Tabs';
 import { useToastContext } from '@/components/common/Toast/ToastContext';
 import { ROUTE_PATH } from '@/constants/routePath';
 import useChecklistAnswer from '@/hooks/useChecklistAnswer';
@@ -27,6 +28,37 @@ const DefaultRoomInfo: RoomInfo = {
   walkingTime: 10,
   realEstate: '방끗공인중개사',
 };
+
+const categoryTabs: Tab[] = [
+  {
+    id: 1,
+    categoryName: '청결',
+  },
+  {
+    id: 2,
+    categoryName: '방 컨디션',
+  },
+  {
+    id: 3,
+    categoryName: '편의시설',
+  },
+  {
+    id: 4,
+    categoryName: '옵션',
+  },
+  {
+    id: 5,
+    categoryName: '주거환경',
+  },
+  {
+    id: 6,
+    categoryName: '보안',
+  },
+  {
+    id: 7,
+    categoryName: '경제적',
+  },
+];
 
 const NewChecklistPage = () => {
   const { showToast } = useToastContext();
@@ -78,8 +110,9 @@ const NewChecklistPage = () => {
         right={<Button label={'저장'} size="small" color="dark" onClick={onSubmitChecklist} />}
       />
 
-      <TabProvider>
+      <TabProvider tabList={categoryTabs}>
         <NewChecklistTabContainer
+          categoryTabs={categoryTabs}
           roomInfo={roomInfo}
           onChange={onChange}
           selectedOptions={selectedOptions}

--- a/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
@@ -5,28 +5,15 @@ import { useNavigate } from 'react-router-dom';
 import { postChecklist } from '@/apis/checklist';
 import Button from '@/components/common/Button/Button';
 import Header from '@/components/common/Header/Header';
+import { TabProvider } from '@/components/common/Tabs/TabContext';
 import { useToastContext } from '@/components/common/Toast/ToastContext';
 import { ROUTE_PATH } from '@/constants/routePath';
 import useChecklistAnswer from '@/hooks/useChecklistAnswer';
 import useInputs from '@/hooks/useInput';
-import NewChecklistInfoTemplate from '@/pages/NewChecklistPage/NewChecklistInfoTemplate';
-import NewChecklistTemplate from '@/pages/NewChecklistPage/NewChecklistTemplate';
+import NewChecklistTabContainer from '@/pages/NewChecklistPage/NewChecklistTabContainer';
 import { flexCenter, flexColumn, title2 } from '@/styles/common';
 import { ChecklistFormAfterAnswer } from '@/types/checklist';
 import { RoomInfo } from '@/types/room';
-
-export type TemplateType = 'checklist' | 'info';
-
-// const menuList: Menu[] = [
-//   {
-//     name: '기본 정보',
-//     id: 'info',
-//   },
-//   {
-//     name: '체크리스트',
-//     id: 'checklist',
-//   },
-// ];
 
 // TODO: roomName 이슈로 인해 데모 버전으로 변경
 const DefaultRoomInfo: RoomInfo = {
@@ -42,12 +29,7 @@ const DefaultRoomInfo: RoomInfo = {
 };
 
 const NewChecklistPage = () => {
-  // const [currentTemplateId, setCurrentTemplateId] = useState<string>(menuList[0].id);
   const { showToast } = useToastContext();
-
-  // const onMoveTemplate = (templateId: TemplateType) => {
-  //   setCurrentTemplateId(templateId);
-  // };
 
   /*방 기본 정보 */
   const { values: roomInfo, onChange } = useInputs(DefaultRoomInfo);
@@ -95,22 +77,18 @@ const NewChecklistPage = () => {
         center={<S.Title>{'새 체크리스트'}</S.Title>}
         right={<Button label={'저장'} size="small" color="dark" onClick={onSubmitChecklist} />}
       />
-      {/* <Tabs menuList={menuList} onMoveMenu={onMoveTemplate} currentMenuId={currentTemplateId} /> */}
-      {currentTemplateId === 'info' ? (
-        <NewChecklistInfoTemplate
+
+      <TabProvider>
+        <NewChecklistTabContainer
           roomInfo={roomInfo}
           onChange={onChange}
           selectedOptions={selectedOptions}
           setSelectedOptions={setSelectedOptions}
-        />
-      ) : (
-        <NewChecklistTemplate
-          answers={checklistAnswers}
           addAnswer={addAnswer}
           deleteAnswer={deleteAnswer}
           questionSelectedAnswer={questionSelectedAnswer}
         />
-      )}
+      </TabProvider>
     </S.Container>
   );
 };

--- a/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
@@ -29,7 +29,7 @@ const DefaultRoomInfo: RoomInfo = {
   realEstate: '방끗공인중개사',
 };
 
-export const categoryTabs: Tab[] = [
+export const newChecklistTabs: Tab[] = [
   { id: 0, name: '기본 정보' },
   {
     id: 1,
@@ -113,7 +113,7 @@ const NewChecklistPage = () => {
 
       <TabProvider>
         <NewChecklistBody
-          categoryTabs={categoryTabs}
+          newChecklistTabs={newChecklistTabs}
           roomInfo={roomInfo}
           onChange={onChange}
           selectedOptions={selectedOptions}
@@ -121,6 +121,7 @@ const NewChecklistPage = () => {
           addAnswer={addAnswer}
           deleteAnswer={deleteAnswer}
           questionSelectedAnswer={questionSelectedAnswer}
+          checklistAnswers={checklistAnswers}
         />
       </TabProvider>
     </S.Container>

--- a/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from 'react-router-dom';
 import { postChecklist } from '@/apis/checklist';
 import Button from '@/components/common/Button/Button';
 import Header from '@/components/common/Header/Header';
-import Tabs, { Menu } from '@/components/common/Tabs/Tabs';
 import { useToastContext } from '@/components/common/Toast/ToastContext';
 import { ROUTE_PATH } from '@/constants/routePath';
 import useChecklistAnswer from '@/hooks/useChecklistAnswer';
@@ -18,16 +17,16 @@ import { RoomInfo } from '@/types/room';
 
 export type TemplateType = 'checklist' | 'info';
 
-const menuList: Menu[] = [
-  {
-    name: '기본 정보',
-    id: 'info',
-  },
-  {
-    name: '체크리스트',
-    id: 'checklist',
-  },
-];
+// const menuList: Menu[] = [
+//   {
+//     name: '기본 정보',
+//     id: 'info',
+//   },
+//   {
+//     name: '체크리스트',
+//     id: 'checklist',
+//   },
+// ];
 
 // TODO: roomName 이슈로 인해 데모 버전으로 변경
 const DefaultRoomInfo: RoomInfo = {
@@ -43,12 +42,12 @@ const DefaultRoomInfo: RoomInfo = {
 };
 
 const NewChecklistPage = () => {
-  const [currentTemplateId, setCurrentTemplateId] = useState<string>(menuList[0].id);
+  // const [currentTemplateId, setCurrentTemplateId] = useState<string>(menuList[0].id);
   const { showToast } = useToastContext();
 
-  const onMoveTemplate = (templateId: TemplateType) => {
-    setCurrentTemplateId(templateId);
-  };
+  // const onMoveTemplate = (templateId: TemplateType) => {
+  //   setCurrentTemplateId(templateId);
+  // };
 
   /*방 기본 정보 */
   const { values: roomInfo, onChange } = useInputs(DefaultRoomInfo);
@@ -96,7 +95,7 @@ const NewChecklistPage = () => {
         center={<S.Title>{'새 체크리스트'}</S.Title>}
         right={<Button label={'저장'} size="small" color="dark" onClick={onSubmitChecklist} />}
       />
-      <Tabs menuList={menuList} onMoveMenu={onMoveTemplate} currentMenuId={currentTemplateId} />
+      {/* <Tabs menuList={menuList} onMoveMenu={onMoveTemplate} currentMenuId={currentTemplateId} /> */}
       {currentTemplateId === 'info' ? (
         <NewChecklistInfoTemplate
           roomInfo={roomInfo}

--- a/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
@@ -11,7 +11,7 @@ import { useToastContext } from '@/components/common/Toast/ToastContext';
 import { ROUTE_PATH } from '@/constants/routePath';
 import useChecklistAnswer from '@/hooks/useChecklistAnswer';
 import useInputs from '@/hooks/useInput';
-import NewChecklistTabContainer from '@/pages/NewChecklistPage/NewChecklistTabContainer';
+import NewChecklistBody from '@/pages/NewChecklistPage/NewChecklistBody';
 import { flexCenter, flexColumn, title2 } from '@/styles/common';
 import { ChecklistFormAfterAnswer } from '@/types/checklist';
 import { RoomInfo } from '@/types/room';
@@ -111,8 +111,8 @@ const NewChecklistPage = () => {
         right={<Button label={'저장'} size="small" color="dark" onClick={onSubmitChecklist} />}
       />
 
-      <TabProvider tabList={categoryTabs}>
-        <NewChecklistTabContainer
+      <TabProvider>
+        <NewChecklistBody
           categoryTabs={categoryTabs}
           roomInfo={roomInfo}
           onChange={onChange}

--- a/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistPage.tsx
@@ -29,34 +29,35 @@ const DefaultRoomInfo: RoomInfo = {
   realEstate: '방끗공인중개사',
 };
 
-const categoryTabs: Tab[] = [
+export const categoryTabs: Tab[] = [
+  { id: 0, name: '기본 정보' },
   {
     id: 1,
-    categoryName: '청결',
+    name: '청결',
   },
   {
     id: 2,
-    categoryName: '방 컨디션',
+    name: '방 컨디션',
   },
   {
     id: 3,
-    categoryName: '편의시설',
+    name: '편의시설',
   },
   {
     id: 4,
-    categoryName: '옵션',
+    name: '옵션',
   },
   {
     id: 5,
-    categoryName: '주거환경',
+    name: '주거환경',
   },
   {
     id: 6,
-    categoryName: '보안',
+    name: '보안',
   },
   {
     id: 7,
-    categoryName: '경제적',
+    name: '경제적',
   },
 ];
 

--- a/frontend/src/pages/NewChecklistPage/NewChecklistTabContainer.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistTabContainer.tsx
@@ -7,18 +7,8 @@ import { RoomInfo } from '@/types/room';
 
 export type TemplateType = 'checklist' | 'info';
 
-const categoryTabs: Tab[] = [
-  {
-    name: '기본 정보',
-    id: 'info',
-  },
-  {
-    name: '체크리스트',
-    id: 'checklist',
-  },
-];
-
 interface Props {
+  categoryTabs: Tab[];
   selectedOptions: number[];
   setSelectedOptions: React.Dispatch<React.SetStateAction<number[]>>;
   roomInfo: RoomInfo;
@@ -29,8 +19,16 @@ interface Props {
 }
 
 const NewChecklistTabContainer = (props: Props) => {
-  const { roomInfo, onChange, selectedOptions, setSelectedOptions, addAnswer, deleteAnswer, questionSelectedAnswer } =
-    props;
+  const {
+    categoryTabs,
+    roomInfo,
+    onChange,
+    selectedOptions,
+    setSelectedOptions,
+    addAnswer,
+    deleteAnswer,
+    questionSelectedAnswer,
+  } = props;
   const { currentTabId } = useTabContext();
 
   const renderTabContent = () => {

--- a/frontend/src/pages/NewChecklistPage/NewChecklistTabContainer.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistTabContainer.tsx
@@ -1,0 +1,67 @@
+import { useTabContext } from '@/components/common/Tabs/TabContext';
+import Tabs, { Tab } from '@/components/common/Tabs/Tabs';
+import { addAnswerProps } from '@/pages/ChecklistSummaryPage';
+import NewChecklistInfoTemplate from '@/pages/NewChecklistPage/NewChecklistInfoTemplate';
+import NewChecklistTemplate from '@/pages/NewChecklistPage/NewChecklistTemplate';
+import { RoomInfo } from '@/types/room';
+
+export type TemplateType = 'checklist' | 'info';
+
+const categoryTabs: Tab[] = [
+  {
+    name: '기본 정보',
+    id: 'info',
+  },
+  {
+    name: '체크리스트',
+    id: 'checklist',
+  },
+];
+
+interface Props {
+  selectedOptions: number[];
+  setSelectedOptions: React.Dispatch<React.SetStateAction<number[]>>;
+  roomInfo: RoomInfo;
+  onChange: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  addAnswer: ({ questionId, newAnswer }: addAnswerProps) => void;
+  deleteAnswer: (questionId: number) => void;
+  questionSelectedAnswer: (questionId: number) => number | undefined;
+}
+
+const NewChecklistTabContainer = (props: Props) => {
+  const { roomInfo, onChange, selectedOptions, setSelectedOptions, addAnswer, deleteAnswer, questionSelectedAnswer } =
+    props;
+  const { currentTabId } = useTabContext();
+
+  const renderTabContent = () => {
+    switch (currentTabId) {
+      case 'info':
+        return (
+          <NewChecklistInfoTemplate
+            roomInfo={roomInfo}
+            onChange={onChange}
+            selectedOptions={selectedOptions}
+            setSelectedOptions={setSelectedOptions}
+          />
+        );
+      case 'checklist':
+        return (
+          <NewChecklistTemplate
+            addAnswer={addAnswer}
+            deleteAnswer={deleteAnswer}
+            questionSelectedAnswer={questionSelectedAnswer}
+          />
+        );
+      default:
+        return <div>콘텐츠가 없습니다.</div>;
+    }
+  };
+  return (
+    <div>
+      <Tabs tabList={categoryTabs} />
+      {currentTabId && renderTabContent()}
+    </div>
+  );
+};
+
+export default NewChecklistTabContainer;

--- a/frontend/src/pages/NewChecklistPage/NewChecklistTabContainer.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistTabContainer.tsx
@@ -1,8 +1,12 @@
+import { useEffect, useState } from 'react';
+
+import { getChecklistQuestions } from '@/apis/checklist';
 import { useTabContext } from '@/components/common/Tabs/TabContext';
 import Tabs, { Tab } from '@/components/common/Tabs/Tabs';
 import { addAnswerProps } from '@/pages/ChecklistSummaryPage';
 import NewChecklistInfoTemplate from '@/pages/NewChecklistPage/NewChecklistInfoTemplate';
 import NewChecklistTemplate from '@/pages/NewChecklistPage/NewChecklistTemplate';
+import { ChecklistCategoryQuestions } from '@/types/checklist';
 import { RoomInfo } from '@/types/room';
 
 export type TemplateType = 'checklist' | 'info';
@@ -31,9 +35,23 @@ const NewChecklistTabContainer = (props: Props) => {
   } = props;
   const { currentTabId } = useTabContext();
 
+  const [checklistQuestions, setChecklistQuestions] = useState<ChecklistCategoryQuestions[]>([]);
+
+  useEffect(() => {
+    const fetchChecklist = async () => {
+      const checklist = await getChecklistQuestions();
+      setChecklistQuestions(checklist);
+    };
+    fetchChecklist();
+  }, []);
+
+  const findQuestions = (targetId: number) => {
+    return checklistQuestions.filter(category => category.categoryId === targetId)[0].questions;
+  };
+
   const renderTabContent = () => {
     switch (currentTabId) {
-      case 'info':
+      case 0:
         return (
           <NewChecklistInfoTemplate
             roomInfo={roomInfo}
@@ -42,9 +60,10 @@ const NewChecklistTabContainer = (props: Props) => {
             setSelectedOptions={setSelectedOptions}
           />
         );
-      case 'checklist':
+      case 1: //청결
         return (
           <NewChecklistTemplate
+            checklistQuestions={findQuestions(currentTabId)}
             addAnswer={addAnswer}
             deleteAnswer={deleteAnswer}
             questionSelectedAnswer={questionSelectedAnswer}

--- a/frontend/src/pages/NewChecklistPage/NewChecklistTemplate.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistTemplate.tsx
@@ -17,27 +17,17 @@ interface Props {
 const NewChecklistTemplate = (props: Props) => {
   const { questionSelectedAnswer, addAnswer, deleteAnswer, checklistQuestions } = props;
 
-  // const [checklistQuestions, setChecklistQuestions] = useState<ChecklistCategoryQuestions[]>([]);
-
-  // useEffect(() => {
-  //   const fetchChecklist = async () => {
-  //     const checklist = await getChecklistQuestions();
-  //     setChecklistQuestions(checklist);
-  //   };
-  //   fetchChecklist();
-  // }, []);
-
   return (
     <S.ContentBox>
       {checklistQuestions?.map(question => (
-        <div key={`question-${question.questionId}`}>
+        <S.QuestionBox key={`question-${question.questionId}`}>
           <ChecklistQuestion
             addAnswer={addAnswer}
             deleteAnswer={deleteAnswer}
             question={question}
             questionSelectedAnswer={questionSelectedAnswer}
           />
-        </div>
+        </S.QuestionBox>
       ))}
     </S.ContentBox>
   );
@@ -46,11 +36,21 @@ const NewChecklistTemplate = (props: Props) => {
 export default NewChecklistTemplate;
 
 const ContentBox = styled.div`
+  display: flex;
   padding: 16px;
-  min-height: 100vh;
+  gap: 10px;
+  flex-direction: column;
 
   background-color: ${({ theme }) => theme.palette.backgroud};
+  min-height: 100vh;
 `;
+
+const QuestionBox = styled.div`
+  background-color: ${({ theme }) => theme.palette.white};
+  border-radius: 8px;
+`;
+
 const S = {
   ContentBox,
+  QuestionBox,
 };

--- a/frontend/src/pages/NewChecklistPage/NewChecklistTemplate.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistTemplate.tsx
@@ -1,10 +1,6 @@
 import styled from '@emotion/styled';
-import { useEffect, useState } from 'react';
 
-import { getChecklistQuestions } from '@/apis/checklist';
-import Accordion from '@/components/common/Accordion/Accordion';
-import ChecklistCategory from '@/components/NewChecklist/ChecklistCategory';
-import { ChecklistCategoryQuestions } from '@/types/checklist';
+import ChecklistQuestion from '@/components/NewChecklist/ChecklistQuestion/ChecklistQuestion';
 
 export interface addAnswerProps {
   questionId: number;
@@ -15,44 +11,34 @@ interface Props {
   addAnswer: ({ questionId, newAnswer }: addAnswerProps) => void;
   deleteAnswer: (questionId: number) => void;
   questionSelectedAnswer: (questionId: number) => number | undefined;
+  checklistQuestions: ChecklistQuestion[];
 }
 
 const NewChecklistTemplate = (props: Props) => {
-  const { questionSelectedAnswer, addAnswer, deleteAnswer } = props;
+  const { questionSelectedAnswer, addAnswer, deleteAnswer, checklistQuestions } = props;
 
-  const [checklistQuestions, setChecklistQuestions] = useState<ChecklistCategoryQuestions[]>([]);
+  // const [checklistQuestions, setChecklistQuestions] = useState<ChecklistCategoryQuestions[]>([]);
 
-  useEffect(() => {
-    const fetchChecklist = async () => {
-      const checklist = await getChecklistQuestions();
-      setChecklistQuestions(checklist);
-    };
-    fetchChecklist();
-  }, []);
+  // useEffect(() => {
+  //   const fetchChecklist = async () => {
+  //     const checklist = await getChecklistQuestions();
+  //     setChecklistQuestions(checklist);
+  //   };
+  //   fetchChecklist();
+  // }, []);
 
   return (
     <S.ContentBox>
-      <Accordion>
-        {checklistQuestions?.map((category, categoryIndex) => (
-          <div key={`category-${category.categoryId}`}>
-            <Accordion.header
-              text={category.categoryName}
-              id={category.categoryId}
-              key={`header-${category.categoryId}`}
-            />
-            <Accordion.body id={category.categoryId} key={`body-${category.categoryId}`}>
-              <ChecklistCategory
-                type="question"
-                key={`category-${category.categoryId}-${categoryIndex}`}
-                category={category}
-                addAnswer={addAnswer}
-                deleteAnswer={deleteAnswer}
-                questionSelectedAnswer={questionSelectedAnswer}
-              />
-            </Accordion.body>
-          </div>
-        ))}
-      </Accordion>
+      {checklistQuestions?.map(question => (
+        <div key={`question-${question.questionId}`}>
+          <ChecklistQuestion
+            addAnswer={addAnswer}
+            deleteAnswer={deleteAnswer}
+            question={question}
+            questionSelectedAnswer={questionSelectedAnswer}
+          />
+        </div>
+      ))}
     </S.ContentBox>
   );
 };

--- a/frontend/src/pages/NewChecklistPage/NewChecklistTemplate.tsx
+++ b/frontend/src/pages/NewChecklistPage/NewChecklistTemplate.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { getChecklistQuestions } from '@/apis/checklist';
 import Accordion from '@/components/common/Accordion/Accordion';
 import ChecklistCategory from '@/components/NewChecklist/ChecklistCategory';
-import { ChecklistCategoryQuestions, ChecklistFormAnswer } from '@/types/checklist';
+import { ChecklistCategoryQuestions } from '@/types/checklist';
 
 export interface addAnswerProps {
   questionId: number;
@@ -14,7 +14,6 @@ export interface addAnswerProps {
 interface Props {
   addAnswer: ({ questionId, newAnswer }: addAnswerProps) => void;
   deleteAnswer: (questionId: number) => void;
-  answers: ChecklistFormAnswer[];
   questionSelectedAnswer: (questionId: number) => number | undefined;
 }
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -46,6 +46,7 @@ const text = {
 /*range: 10~50 */
 const zIndex = {
   FLOATING_BUTTON: 10,
+  TABS: 10,
   MODAL: 20,
   TOAST: 30,
 };

--- a/frontend/src/types/tab.ts
+++ b/frontend/src/types/tab.ts
@@ -1,0 +1,8 @@
+export interface Tab {
+  name: string;
+  id: number;
+}
+
+export interface TabWithCompletion extends Tab {
+  isCompleted: boolean;
+}


### PR DESCRIPTION
## ❗ Issue

- #171 

## ✨ 구현한 기능

(1) 탭을 변경된 디자인으로 리팩토링 하였습니다. 탭의 경우 props drilling 이 심해서 전역 상태인 context로 관리했습니다. 이후 zustand를 도입하면 리팩토링을 할 것 같습니다. 

<img width="306" alt="image" src="https://github.com/user-attachments/assets/26079919-0394-4c74-9921-3f413e574e0a">

<img width="311" alt="image" src="https://github.com/user-attachments/assets/e04162e7-fd5f-46c3-885d-82df04a098bb">

(2) 일부 setter 함수에서 타입에러를 수정하였습니다. 

ex ) setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;

## 📢 논의하고 싶은 내용

코멘트로 질문하나 남겨놓겠습니다!

## 🎸 기타

현재 각 탭의 답변 완료 여부를 표시해주는 점 indicator 의 로직을 하고 있습니다. 

