### PR TITLE
[BE] 체크리스트 삭제 API를 구현한다

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/controller/ChecklistController.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/controller/ChecklistController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -61,6 +62,12 @@ public class ChecklistController {
     @PutMapping("/custom-checklist")
     public ResponseEntity<Void> updateCustomChecklist(@RequestBody CustomChecklistUpdateRequest request) {
         checklistService.updateCustomChecklist(request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/checklists/{id}")
+    public ResponseEntity<Void> deleteChecklistById(@PathVariable("id") long id) {
+        checklistService.deleteChecklistById(id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/domain/Grade.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/domain/Grade.java
@@ -10,6 +10,7 @@ public enum Grade {
     GOOD(3),
     SOSO(2),
     BAD(1),
+    NONE(0)
     ;
 
     private final int score;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/repository/ChecklistRepository.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/repository/ChecklistRepository.java
@@ -12,20 +12,24 @@ import java.util.Optional;
 
 public interface ChecklistRepository extends JpaRepository<Checklist, Long> {
 
-    //TODO 테스트해야 함
+    //TODO: 논리적 삭제 리팩토링
     @Query("SELECT c FROM Checklist c "
             + "JOIN FETCH Room r "
             + "ON c.id = :id "
             + "AND c.room.id = r.id")
     Optional<Checklist> findById(@Param("id") long id);
 
+    //TODO: 논리적 삭제 리팩토링
     default Checklist getById(long id) {
         return findById(id).orElseThrow(() -> new BangggoodException(ExceptionCode.CHECKLIST_NOT_FOUND));
     }
 
+    //TODO: 논리적 삭제 리팩토링
     List<Checklist> findByUser(User user);
 
+    //TODO: 논리적 삭제 리팩토링
     List<Checklist> findByUserAndIdIn(User user, List<Long> checklistIds);
 
+    //TODO: 논리적 삭제 리팩토링
     long countAllByIdIn(List<Long> ids);
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/repository/ChecklistRepository.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/repository/ChecklistRepository.java
@@ -5,6 +5,7 @@ import com.bang_ggood.exception.BangggoodException;
 import com.bang_ggood.exception.ExceptionCode;
 import com.bang_ggood.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import java.util.List;
@@ -12,14 +13,13 @@ import java.util.Optional;
 
 public interface ChecklistRepository extends JpaRepository<Checklist, Long> {
 
-    //TODO: 논리적 삭제 리팩토링
     @Query("SELECT c FROM Checklist c "
-            + "JOIN FETCH Room r "
-            + "ON c.id = :id "
-            + "AND c.room.id = r.id")
+            + "JOIN FETCH c.room r "
+            + "WHERE c.id = :id "
+            + "AND c.room.id = r.id "
+            + "AND c.deleted = false")
     Optional<Checklist> findById(@Param("id") long id);
 
-    //TODO: 논리적 삭제 리팩토링
     default Checklist getById(long id) {
         return findById(id).orElseThrow(() -> new BangggoodException(ExceptionCode.CHECKLIST_NOT_FOUND));
     }
@@ -32,4 +32,16 @@ public interface ChecklistRepository extends JpaRepository<Checklist, Long> {
 
     //TODO: 논리적 삭제 리팩토링
     long countAllByIdIn(List<Long> ids);
+
+    @Query("SELECT COUNT(c) > 0 FROM Checklist c "
+            + "WHERE c.id = :id "
+            + "AND c.deleted = false")
+    boolean existsById(@Param("id") long id);
+
+    @Modifying
+    @Query("UPDATE Checklist c "
+            + "SET c.deleted = true "
+            + "WHERE c.id = :id")
+    void deleteById(@Param("id") long id);
+    
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
@@ -314,6 +314,7 @@ public class ChecklistService {
 
     @Transactional
     public void deleteChecklistById(long id) {
+        // 사용자 검증 필요
         if (!checklistRepository.existsById(id)) {
             throw new BangggoodException(ExceptionCode.CHECKLIST_NOT_FOUND);
         }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
@@ -118,7 +118,7 @@ public class ChecklistService {
                 .map(question -> new ChecklistQuestion(
                         checklist,
                         Question.fromId(question.questionId()),
-                        question.grade() == null ? null : Grade.from(question.grade()),
+                        Grade.from(question.grade()),
                         question.memo()))
                 .collect(Collectors.toList());
         checklistQuestionRepository.saveAll(checklistQuestions);

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
@@ -118,7 +118,7 @@ public class ChecklistService {
                 .map(question -> new ChecklistQuestion(
                         checklist,
                         Question.fromId(question.questionId()),
-                        Grade.from(question.grade()),
+                        question.grade() == null ? null : Grade.from(question.grade()),
                         question.memo()))
                 .collect(Collectors.toList());
         checklistQuestionRepository.saveAll(checklistQuestions);
@@ -310,5 +310,13 @@ public class ChecklistService {
         if (questionIds.size() != Set.copyOf(questionIds).size()) {
             throw new BangggoodException(ExceptionCode.QUESTION_DUPLICATED);
         }
+    }
+
+    @Transactional
+    public void deleteChecklistById(long id) {
+        if (!checklistRepository.existsById(id)) {
+            throw new BangggoodException(ExceptionCode.CHECKLIST_NOT_FOUND);
+        }
+        checklistRepository.deleteById(id);
     }
 }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/ChecklistFixture.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/ChecklistFixture.java
@@ -32,11 +32,8 @@ public class ChecklistFixture {
             5, "GOOD", null
     );
 
-    public static final QuestionCreateRequest QUESTION_CREATE_REQUEST_NO_ANSWER = new QuestionCreateRequest(
-            6, null, "메모6"
-    );
     public static final QuestionCreateRequest QUESTION_CREATE_REQUEST_NO_ID = new QuestionCreateRequest(
-            null, "GOOD", "메모"
+            null, "NONE", "메모"
     );
 
     public static final QuestionCreateRequest QUESTION_CREATE_REQUEST_INVALID_ID = new QuestionCreateRequest(

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/controller/ChecklistE2ETest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/controller/ChecklistE2ETest.java
@@ -110,4 +110,17 @@ public class ChecklistE2ETest extends AcceptanceTest {
                 .then().log().all()
                 .statusCode(204);
     }
+
+    @DisplayName("체크리스트 삭제 성공")
+    @Test
+    void deleteChecklistById() {
+        roomRepository.save(RoomFixture.ROOM_1);
+        Checklist saved = checklistRepository.save(ChecklistFixture.checklist);
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when().delete("/checklists/" + saved.getId())
+                .then().log().all()
+                .statusCode(204);
+    }
 }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/domain/QuestionTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/domain/QuestionTest.java
@@ -57,7 +57,7 @@ class QuestionTest {
                 .hasMessage(ExceptionCode.QUESTION_INVALID.getMessage());
     }
 
-    @DisplayName("질문 아이디를 통해 포함되어 있는지 확인 : 포함일 경우")
+    @DisplayName("질문 아이디를 통해 포함되어 있는지 확인 성공 : 포함일 경우")
     @Test
     void contains_true() {
         //given
@@ -67,7 +67,7 @@ class QuestionTest {
         assertThat(Question.contains(questionId)).isTrue();
     }
 
-    @DisplayName("질문 아이디를 통해 포함되어 있는지 확인 : 포함이 아닐 경우")
+    @DisplayName("질문 아이디를 통해 포함되어 있는지 확인 성공 : 포함이 아닐 경우")
     @Test
     void contains_false() {
         //given

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/repository/ChecklistRepositoryTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/repository/ChecklistRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.bang_ggood.checklist.repository;
+
+import com.bang_ggood.IntegrationTestSupport;
+import com.bang_ggood.checklist.ChecklistFixture;
+import com.bang_ggood.checklist.domain.Checklist;
+import com.bang_ggood.exception.BangggoodException;
+import com.bang_ggood.exception.ExceptionCode;
+import com.bang_ggood.room.RoomFixture;
+import com.bang_ggood.room.repository.RoomRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+class ChecklistRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ChecklistRepository checklistRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @BeforeEach
+    void setUp() {
+        roomRepository.save(RoomFixture.ROOM_1);
+    }
+
+    @DisplayName("아이디를 통해 체크리스트 갖고 오기 성공")
+    @Test
+    void findById() {
+        //given
+        Checklist savedChecklist = checklistRepository.save(ChecklistFixture.checklist);
+
+        //when
+        Checklist foundChecklist = checklistRepository.getById(savedChecklist.getId().longValue());
+
+        //then
+        assertThat(foundChecklist.getId()).isEqualTo(ChecklistFixture.checklist.getId());
+    }
+
+    @DisplayName("아이디를 통해 체크리스트 갖고 오기 실패 : 해당하는 체크리스트가 없을 경우")
+    @Test
+    void findById_notFound_exception() {
+        assertThatThrownBy(() -> checklistRepository.getById(1))
+                .isInstanceOf(BangggoodException.class)
+                .hasMessage(ExceptionCode.CHECKLIST_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("아이디를 통해 체크리스트 존재 확인 : 존재하는 경우")
+    @Test
+    void existsById_true() {
+        //given & when
+        Checklist savedChecklist = checklistRepository.save(ChecklistFixture.checklist);
+
+        //then
+        assertThat(checklistRepository.existsById(savedChecklist.getId().longValue())).isTrue();
+    }
+
+    @DisplayName("아이디를 통해 체크리스트 존재 확인 : 존재하지 않는 경우")
+    @Test
+    void existsById_false() {
+        //given & when & then
+        assertThat(checklistRepository.existsById(1)).isFalse();
+    }
+
+    @DisplayName("체크리스트 삭제 성공")
+    @Test
+    void deleteById() {
+        //given
+        Checklist savedChecklist = checklistRepository.save(ChecklistFixture.checklist);
+
+        //when
+        checklistRepository.deleteById(savedChecklist.getId().longValue());
+
+        //then
+        assertAll(
+                () -> assertThat(checklistRepository.existsById(savedChecklist.getId())).isTrue(),
+                () -> assertThat(checklistRepository.existsById(savedChecklist.getId().longValue())).isFalse()
+        );
+    }
+}

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/repository/ChecklistRepositoryTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/repository/ChecklistRepositoryTest.java
@@ -52,7 +52,7 @@ class ChecklistRepositoryTest extends IntegrationTestSupport {
                 .hasMessage(ExceptionCode.CHECKLIST_NOT_FOUND.getMessage());
     }
 
-    @DisplayName("아이디를 통해 체크리스트 존재 확인 : 존재하는 경우")
+    @DisplayName("아이디를 통해 체크리스트 존재 확인 성공 : 존재하는 경우")
     @Test
     void existsById_true() {
         //given & when
@@ -62,7 +62,7 @@ class ChecklistRepositoryTest extends IntegrationTestSupport {
         assertThat(checklistRepository.existsById(savedChecklist.getId().longValue())).isTrue();
     }
 
-    @DisplayName("아이디를 통해 체크리스트 존재 확인 : 존재하지 않는 경우")
+    @DisplayName("아이디를 통해 체크리스트 존재 확인 성공 : 존재하지 않는 경우")
     @Test
     void existsById_false() {
         //given & when & then

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/service/ChecklistServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/service/ChecklistServiceTest.java
@@ -4,8 +4,8 @@ import com.bang_ggood.IntegrationTestSupport;
 import com.bang_ggood.category.domain.Category;
 import com.bang_ggood.checklist.ChecklistFixture;
 import com.bang_ggood.checklist.domain.Checklist;
-import com.bang_ggood.checklist.dto.request.CustomChecklistUpdateRequest;
 import com.bang_ggood.checklist.dto.request.ChecklistCreateRequest;
+import com.bang_ggood.checklist.dto.request.CustomChecklistUpdateRequest;
 import com.bang_ggood.checklist.dto.response.ChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistsWithScoreReadResponse;
 import com.bang_ggood.checklist.dto.response.SelectedChecklistResponse;
@@ -18,10 +18,10 @@ import com.bang_ggood.room.RoomFixture;
 import com.bang_ggood.room.domain.Room;
 import com.bang_ggood.room.repository.RoomRepository;
 import com.bang_ggood.user.domain.User;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
 
 import static com.bang_ggood.checklist.CustomChecklistFixture.CUSTOM_CHECKLIST_UPDATE_REQUEST;
 import static com.bang_ggood.checklist.CustomChecklistFixture.CUSTOM_CHECKLIST_UPDATE_REQUEST_DUPLICATED;
@@ -46,9 +46,9 @@ class ChecklistServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private RoomRepository roomRepository;
+
     @Autowired
     private CustomChecklistQuestionRepository customChecklistQuestionRepository;
-
 
     @DisplayName("체크리스트 방 정보 작성 성공")
     @Test
@@ -313,5 +313,28 @@ class ChecklistServiceTest extends IntegrationTestSupport {
 
     public static Checklist createChecklist(User user, Room room) {
         return new Checklist(user, room, 1000, 60, 24, "방끗부동산");
+    }
+
+    @DisplayName("체크리스트 삭제 성공")
+    @Test
+    void deleteChecklistById() {
+        // given
+        roomRepository.save(RoomFixture.ROOM_1);
+        Checklist checklist = checklistRepository.save(ChecklistFixture.checklist);
+
+        // when
+        checklistService.deleteChecklistById(checklist.getId());
+
+        // then
+        assertThat(checklistRepository.existsById(checklist.getId().longValue())).isFalse();
+    }
+
+    @DisplayName("체크리스트 삭제 실패")
+    @Test
+    void deleteChecklistById_notFound_exception() {
+        // given & when & then
+       assertThatThrownBy(() -> checklistService.deleteChecklistById(-1))
+               .isInstanceOf(BangggoodException.class)
+               .hasMessage(ExceptionCode.CHECKLIST_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## ❗ Issue
- #195 

## ✨ 구현한 기능
- grade null 값 받을 수 있도록 수정
- 체크리스트 단건 조회 논리적 삭제 도입
- 체크리스트 단건 삭제 논리적 삭제 도입


## 📢 논의하고 싶은 내용


## 🎸 기타
 **CRUD Service 코드 작성 시 유의**하셔야 할 것 같아 언급드립니다
repository에서 조회 및 삭제는 논리적 삭제 및 n+1 문제를 해결하기 위해 
저희가 함수를 재정의하고 query문을 작성해야 하는데요!
컨벤션으로 정했듯 내부적으로 id는 Long이 아닌 long을 쓰기로 했었습니다
이때 JPA에서 사용하는 id는 Long 형태이고, 저희가 재정의하는 함수는 long이에요
따라서 파라미터를 long으로 넘기면 재정의하는 함수가 호출되고 Long으로 넘기면 기존의 JPA 함수가 호출돼요
그 부분을 유의하여 코드를 작성해야 문제가 발생하지 않습니다
=> 혹시 실수가 발생할 수 있을 가능성이 있어서 repository에서 Long을 쓰는 것도 고려해 봐도 좋을 듯해요~