### PR TITLE
[FE] svgr의 width, height를 바로 사용할수있게 한다

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -60,7 +60,25 @@ const config: StorybookConfig = {
       {
         test: /\.svg$/i,
         issuer: /\.[jt]sx?$/,
-        use: [{ loader: '@svgr/webpack', options: {} }],
+        use: [
+          {
+            loader: '@svgr/webpack',
+            options: {
+              svgoConfig: {
+                plugins: [
+                  {
+                    name: 'preset-default',
+                    params: {
+                      overrides: {
+                        removeViewBox: false,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
       },
     ];
 

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -71,7 +71,25 @@ const config = {
       {
         test: /\.svg$/i,
         issuer: /\.[jt]sx?$/,
-        use: [{ loader: '@svgr/webpack', options: {} }],
+        use: [
+          {
+            loader: '@svgr/webpack',
+            options: {
+              svgoConfig: {
+                plugins: [
+                  {
+                    name: 'preset-default',
+                    params: {
+                      overrides: {
+                        removeViewBox: false,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## ❗ Issue

- #222 

## ✨ 구현한 기능

별도의 작업 없이 svgr에 width, height prop으로 전달 시 바로 사용할 수 있게 설정변경


## 스크린샷
사용법 : 별도의 작업없이 width에 prop으로 넘겨서 사용하면됩니다.

예시로 Soso에 width, height를 넣어 크게만들어준 모습입니다.
![image](https://github.com/user-attachments/assets/8d38a74d-1967-48d4-b255-401c46123d4f)

## 📢 논의하고 싶은 내용
.


## 🎸 기타

