### PR TITLE
[BE] 커스텀 체크리스트 질문을 전체 조회한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/controller/ChecklistController.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/controller/ChecklistController.java
@@ -3,6 +3,7 @@ package com.bang_ggood.checklist.controller;
 import com.bang_ggood.auth.config.AuthPrincipal;
 import com.bang_ggood.checklist.dto.request.ChecklistRequest;
 import com.bang_ggood.checklist.dto.request.CustomChecklistUpdateRequest;
+import com.bang_ggood.checklist.dto.response.CategoryCustomChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistsWithScoreReadResponse;
 import com.bang_ggood.checklist.dto.response.SelectedChecklistResponse;
@@ -55,6 +56,11 @@ public class ChecklistController {
     @GetMapping("/checklists/comparison")
     public ResponseEntity<ChecklistsWithScoreReadResponse> readChecklistsComparison(@AuthPrincipal User user, @RequestParam("id") List<Long> checklistIds) {
         return ResponseEntity.ok(checklistService.readChecklistsComparison(user, checklistIds));
+    }
+
+    @GetMapping("/custom-checklist/all")
+    public ResponseEntity<CategoryCustomChecklistQuestionsResponse> readAllCustomChecklistQuestions(@AuthPrincipal User user) {
+        return ResponseEntity.ok(checklistService.readAllCustomChecklistQuestions(user));
     }
 
     @PutMapping("/checklists/{id}")

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/domain/Question.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/domain/Question.java
@@ -98,6 +98,11 @@ public enum Question {
                 .anyMatch(question -> question.getId() == id);
     }
 
+    public boolean isSelected(List<CustomChecklistQuestion> questions) {
+        return questions.stream()
+                .anyMatch(question -> question.getQuestion().id == this.id);
+    }
+
     private boolean isCategory(Category category) {
         return this.category == category;
     }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/dto/response/CategoryCustomChecklistQuestionResponse.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/dto/response/CategoryCustomChecklistQuestionResponse.java
@@ -1,0 +1,7 @@
+package com.bang_ggood.checklist.dto.response;
+
+import java.util.List;
+
+public record CategoryCustomChecklistQuestionResponse(Integer categoryId, String categoryName,
+                                                      List<CustomChecklistQuestionResponse> questions) {
+}

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/dto/response/CategoryCustomChecklistQuestionsResponse.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/dto/response/CategoryCustomChecklistQuestionsResponse.java
@@ -1,0 +1,6 @@
+package com.bang_ggood.checklist.dto.response;
+
+import java.util.List;
+
+public record CategoryCustomChecklistQuestionsResponse(List<CategoryCustomChecklistQuestionResponse> categories) {
+}

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/dto/response/CustomChecklistQuestionResponse.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/dto/response/CustomChecklistQuestionResponse.java
@@ -1,0 +1,10 @@
+package com.bang_ggood.checklist.dto.response;
+
+import com.bang_ggood.checklist.domain.Question;
+
+public record CustomChecklistQuestionResponse(Integer questionId, String title, String subtitle,
+                                              boolean isSelected) {
+    public static CustomChecklistQuestionResponse of(Question question, boolean isSelected) {
+        return new CustomChecklistQuestionResponse(question.getId(), question.getTitle(), question.getSubtitle(), isSelected);
+    }
+}

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
@@ -18,10 +18,13 @@ import com.bang_ggood.checklist.dto.request.ChecklistRequest;
 import com.bang_ggood.checklist.dto.request.CustomChecklistUpdateRequest;
 import com.bang_ggood.checklist.dto.request.QuestionRequest;
 import com.bang_ggood.checklist.dto.response.BadgeResponse;
+import com.bang_ggood.checklist.dto.response.CategoryCustomChecklistQuestionResponse;
+import com.bang_ggood.checklist.dto.response.CategoryCustomChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.CategoryScoreReadResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistWithScoreReadResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistsWithScoreReadResponse;
+import com.bang_ggood.checklist.dto.response.CustomChecklistQuestionResponse;
 import com.bang_ggood.checklist.dto.response.QuestionResponse;
 import com.bang_ggood.checklist.dto.response.SelectedChecklistResponse;
 import com.bang_ggood.checklist.dto.response.SelectedOptionResponse;
@@ -40,6 +43,7 @@ import com.bang_ggood.room.repository.RoomRepository;
 import com.bang_ggood.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -164,6 +168,28 @@ public class ChecklistService {
                 throw new BangggoodException(ExceptionCode.QUESTION_INVALID);
             }
         }
+    }
+
+    @Transactional
+    public CategoryCustomChecklistQuestionsResponse readAllCustomChecklistQuestions(User user) { // TODO custom-checklist 도메인 분리 및 리팩토링
+        List<CustomChecklistQuestion> customChecklistQuestions = customChecklistQuestionRepository.findAllByUser(user);
+        List<CategoryCustomChecklistQuestionResponse> allCategoryCustomChecklistQuestions = getAllCategoryCustomChecklistQuestions(customChecklistQuestions);
+
+        return new CategoryCustomChecklistQuestionsResponse(allCategoryCustomChecklistQuestions);
+    }
+
+    private List<CategoryCustomChecklistQuestionResponse> getAllCategoryCustomChecklistQuestions(List<CustomChecklistQuestion> customChecklistQuestions) {
+        List<CategoryCustomChecklistQuestionResponse> response = new ArrayList<>();
+
+        for (Category category : Category.values()) {
+            List<Question> categoryQuestions = Question.findQuestionsByCategory(category);
+            List<CustomChecklistQuestionResponse> questions = categoryQuestions.stream()
+                    .map(question -> CustomChecklistQuestionResponse.of(question, question.isSelected(customChecklistQuestions)))
+                    .toList();
+            response.add(new CategoryCustomChecklistQuestionResponse(category.getId(), category.getName(), questions));
+        }
+
+        return response;
     }
 
     @Transactional

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/controller/ChecklistE2ETest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/controller/ChecklistE2ETest.java
@@ -5,6 +5,7 @@ import com.bang_ggood.category.domain.Category;
 import com.bang_ggood.checklist.ChecklistFixture;
 import com.bang_ggood.checklist.domain.Checklist;
 import com.bang_ggood.checklist.dto.request.CustomChecklistUpdateRequest;
+import com.bang_ggood.checklist.dto.response.CategoryCustomChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.SelectedChecklistResponse;
 import com.bang_ggood.checklist.repository.ChecklistRepository;
@@ -92,11 +93,14 @@ class ChecklistE2ETest extends AcceptanceTest {
     @DisplayName("커스텀 체크리스트 전체 조회 성공")
     @Test
     void readAllCustomChecklistQuestion() {
-        // given
-
-        // when
-
-        // then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .when().get("/custom-checklist/all")
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(CategoryCustomChecklistQuestionsResponse.class);
     }
 
     @DisplayName("작성된 체크리스트 조회 성공")

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/service/ChecklistServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/service/ChecklistServiceTest.java
@@ -5,12 +5,15 @@ import com.bang_ggood.category.domain.Category;
 import com.bang_ggood.checklist.ChecklistFixture;
 import com.bang_ggood.checklist.domain.Checklist;
 import com.bang_ggood.checklist.domain.ChecklistQuestion;
+import com.bang_ggood.checklist.domain.CustomChecklistQuestion;
 import com.bang_ggood.checklist.domain.Grade;
 import com.bang_ggood.checklist.domain.Question;
 import com.bang_ggood.checklist.dto.request.ChecklistRequest;
 import com.bang_ggood.checklist.dto.request.CustomChecklistUpdateRequest;
+import com.bang_ggood.checklist.dto.response.CategoryCustomChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistsWithScoreReadResponse;
+import com.bang_ggood.checklist.dto.response.CustomChecklistQuestionResponse;
 import com.bang_ggood.checklist.dto.response.SelectedChecklistResponse;
 import com.bang_ggood.checklist.repository.ChecklistOptionRepository;
 import com.bang_ggood.checklist.repository.ChecklistQuestionRepository;
@@ -25,6 +28,7 @@ import com.bang_ggood.room.repository.RoomRepository;
 import com.bang_ggood.user.UserFixture;
 import com.bang_ggood.user.domain.User;
 import com.bang_ggood.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -431,6 +435,27 @@ class ChecklistServiceTest extends IntegrationTestSupport {
                         ChecklistFixture.CHECKLIST_UPDATE_REQUEST_DIFFERENT_QUESTION))
                 .isInstanceOf(BangggoodException.class)
                 .hasMessage(ExceptionCode.QUESTION_DIFFERENT.getMessage());
+    }
+
+    @DisplayName("커스텀 체크리스트 조회 성공")
+    @Test
+    void readCustomChecklistQuestions() {
+        // given
+        CustomChecklistQuestion question1 = new CustomChecklistQuestion(USER1, Question.CLEAN_5);
+        CustomChecklistQuestion question2 = new CustomChecklistQuestion(USER1, Question.AMENITY_12);
+        List<CustomChecklistQuestion> questions = List.of(question1, question2);
+        customChecklistQuestionRepository.saveAll(questions);
+
+        // when
+        CategoryCustomChecklistQuestionsResponse response = checklistService.readAllCustomChecklistQuestions(USER1);
+
+        // then
+        long selectedCount = response.categories().stream()
+                .flatMap(category -> category.questions().stream())
+                .filter(CustomChecklistQuestionResponse::isSelected)
+                .count();
+
+        Assertions.assertThat(selectedCount).isEqualTo(questions.size());
     }
 
     @DisplayName("커스텀 체크리스트 업데이트 성공")


### PR DESCRIPTION
## ❗ Issue

- #243 

## ✨ 구현한 기능

- 커스텀 체크리스트 질문을 전체 조회하는 기능을 구현했습니다.
- isSelected 필드로 커스텀 체크리스트 질문 선택 여부를 반환합니다.

## 📢 논의하고 싶은 내용

API URL 의견 받습니다~

현재 커스텀 체크리스트 수정 API URL이 `/custom-checklist`이어서 `/custom-checklist/all`로 설정해두긴 했으나,
체크리스트 조회가 아닌 질문 조회이므로 URL에 question이라는 단어가 들어가면 좋을 듯합니다.
`/custom-checklist-questions/all`으로 바꾸는 건 어떨까요??

## 🎸 기타

