### PR TITLE
[BE] 질문 목록 순서를 카테고리 순으로 정렬한다. 

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistService.java
@@ -40,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -155,9 +156,8 @@ public class ChecklistService {
 
         Map<Category, List<Question>> categoryQuestions = customChecklistQuestions.stream()
                 .map(CustomChecklistQuestion::getQuestion)
-                .collect(Collectors.groupingBy(Question::getCategory));
+                .collect(Collectors.groupingBy(Question::getCategory, LinkedHashMap::new, Collectors.toList()));
 
-        // TODO entrySet 문제 해결
         List<CategoryQuestionsResponse> categoryQuestionsResponses = categoryQuestions.entrySet().stream()
                 .map(categoryQuestionEntry -> CategoryQuestionsResponse.of(
                         categoryQuestionEntry.getKey(),

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/service/ChecklistServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/service/ChecklistServiceTest.java
@@ -14,6 +14,7 @@ import com.bang_ggood.checklist.dto.request.CustomChecklistUpdateRequest;
 import com.bang_ggood.checklist.dto.response.CategoryCustomChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.ChecklistQuestionsResponse;
 import com.bang_ggood.checklist.dto.response.CustomChecklistQuestionResponse;
+import com.bang_ggood.checklist.dto.response.QuestionResponse;
 import com.bang_ggood.checklist.dto.response.SelectedChecklistResponse;
 import com.bang_ggood.checklist.repository.ChecklistLikeRepository;
 import com.bang_ggood.checklist.repository.ChecklistOptionRepository;
@@ -31,8 +32,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Collection;
 import java.util.List;
 
+import static com.bang_ggood.checklist.CustomChecklistFixture.CUSTOM_CHECKLIST_QUESTION_DEFAULT;
 import static com.bang_ggood.checklist.CustomChecklistFixture.CUSTOM_CHECKLIST_UPDATE_REQUEST;
 import static com.bang_ggood.checklist.CustomChecklistFixture.CUSTOM_CHECKLIST_UPDATE_REQUEST_DUPLICATED;
 import static com.bang_ggood.checklist.CustomChecklistFixture.CUSTOM_CHECKLIST_UPDATE_REQUEST_EMPTY;
@@ -177,12 +180,17 @@ class ChecklistServiceTest extends IntegrationTestSupport {
         ChecklistQuestionsResponse checklistQuestionsResponse = checklistService.readChecklistQuestions(USER1);
 
         // then
-        int questionsSize = 0;
-        for (CategoryQuestionsResponse categoryQuestionsResponse : checklistQuestionsResponse.categories()) {
-            questionsSize += categoryQuestionsResponse.questions().size();
-        }
+        List<Integer> defaultQuestionsIds = CUSTOM_CHECKLIST_QUESTION_DEFAULT.stream()
+                .map(CustomChecklistQuestion::getQuestion)
+                .map(Question::getId)
+                .toList();
+        List<Integer> responseQuestionsIds = checklistQuestionsResponse.categories().stream()
+                .map(CategoryQuestionsResponse::questions)
+                .flatMap(Collection::stream)
+                .map(QuestionResponse::questionId)
+                .toList();
 
-        assertThat(questionsSize).isEqualTo(CustomChecklistFixture.CUSTOM_CHECKLIST_QUESTION_DEFAULT.size());
+        assertThat(responseQuestionsIds).containsExactlyElementsOf(defaultQuestionsIds);
     }
 
     @DisplayName("작성된 체크리스트 조회 성공")


### PR DESCRIPTION
## ❗ Issue

- #325 

## ✨ 구현한 기능
질문 목록이 카테고리 아이디 순으로 오지 않는 버그 수정

## 📢 논의하고 싶은 내용


## 🎸 기타

