### PR TITLE
[FE] 인풋 컴포넌트 UI 를 변경 및 주소 검색 모달을 연결한다.

### DIFF
--- a/frontend/src/components/NewChecklist/AddressModal/DaumAddressModal.tsx
+++ b/frontend/src/components/NewChecklist/AddressModal/DaumAddressModal.tsx
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import styled from '@emotion/styled';
+import { useCallback, useEffect, useRef } from 'react';
 
 import Button from '@/components/_common/Button/Button';
 import Modal from '@/components/_common/Modal/Modal';
 import loadPostcode from '@/components/NewChecklist/AddressModal/loadPostcode';
+import useModalOpen from '@/hooks/useModalOpen';
 import { Address, Postcode, PostcodeOptions } from '@/types/address';
 
 declare global {
@@ -15,7 +17,12 @@ declare global {
 
 const scriptUrl = '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
 
-const DaumAddressModal = () => {
+interface Props {
+  setAddress: (address: string) => void;
+}
+
+const DaumAddressModal = ({ setAddress }: Props) => {
+  const { isModalOpen, modalOpen, modalClose } = useModalOpen();
   const postcodeContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -25,14 +32,15 @@ const DaumAddressModal = () => {
   }, []);
 
   const openPostcodeEmbed = useCallback(() => {
-    setIsOpen(true);
+    modalOpen();
     if (window.daum?.Postcode && postcodeContainerRef.current) {
       new window.daum.Postcode({
         width: '100%',
         height: '600px',
         oncomplete: (data: Address) => {
           // TODO: 위도, 경도까지 보내주기
-          console.log(data); // 검색 결과 데이터 출력
+          setAddress(data.address);
+          modalClose();
         },
       }).embed(postcodeContainerRef.current, { q: '' });
     } else {
@@ -40,14 +48,12 @@ const DaumAddressModal = () => {
     }
   }, []);
 
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
     <>
-      <Button size="small" color="dark" label="주소찾기" isSquare={true} onClick={openPostcodeEmbed} />
-      <Modal position="bottom" isOpen={isOpen} onClose={() => setIsOpen(false)}>
+      <S.AddressButton size="xSmall" color="dark" label="주소찾기" isSquare={true} onClick={openPostcodeEmbed} />
+      <Modal position="bottom" isOpen={isModalOpen} onClose={modalClose}>
         <Modal.body>
-          <div ref={postcodeContainerRef} style={{ width: '100%' }} />
+          <div ref={postcodeContainerRef} style={{ width: '100%', marginTop: '10px' }} />
         </Modal.body>
       </Modal>
     </>
@@ -55,3 +61,12 @@ const DaumAddressModal = () => {
 };
 
 export default DaumAddressModal;
+
+const S = {
+  AddressButton: styled(Button)`
+    width: 90px;
+    padding: 5px;
+
+    font-size: ${({ theme }) => theme.text.size.xSmall};
+  `,
+};

--- a/frontend/src/components/NewChecklist/NewChecklistInfoTemplate.tsx
+++ b/frontend/src/components/NewChecklist/NewChecklistInfoTemplate.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/_common/Button/Button';
 import FormField from '@/components/_common/FormField/FormField';
 import Header from '@/components/_common/Header/Header';
 import RadioGroup from '@/components/_common/RadioGroup/RadioGroup';
+import DaumAddressModal from '@/components/NewChecklist/AddressModal/DaumAddressModal';
 import { roomFloorLevels, roomStructures, roomTypes } from '@/constants/roomInfo';
 import checklistRoomInfoStore from '@/store/checklistRoomInfoStore';
 import { flexCenter, flexColumn, flexRow } from '@/styles/common';
@@ -14,7 +15,7 @@ import { InputChangeEvent } from '@/types/event';
 import { RoomInfo, RoomInfoName } from '@/types/room';
 
 const NewChecklistInfoTemplate = () => {
-  const { actions, errorMessage, roomInfo } = useStore(checklistRoomInfoStore);
+  const { actions, roomInfo, errorMessage } = useStore(checklistRoomInfoStore);
 
   const handleClickTagButton = useCallback(
     (name: keyof RoomInfo, value: string) => {
@@ -22,6 +23,10 @@ const NewChecklistInfoTemplate = () => {
     },
     [actions],
   );
+
+  const handleSetAddress = (address: string) => {
+    actions.set('address', address);
+  };
 
   return (
     <S.ContentWrapper>
@@ -37,13 +42,14 @@ const NewChecklistInfoTemplate = () => {
           <FormField.Label label="주소" />
           <S.FlexHorizontal gap="3%">
             <S.CustomInput onChange={actions.onChange} name="address" value={roomInfo.address} />
-            <S.AddressButton isSquare={true} label="주소찾기" size="medium" color="dark" />
+            <DaumAddressModal setAddress={handleSetAddress} />
           </S.FlexHorizontal>
           <FormField.ErrorMessage value={errorMessage.address ?? ''} />
         </FormField>
         {/* 교통편 */}
         <S.FlexVertical gap="15px">
           <FormField.Label label="가까운 교통편" />
+          {/* TODO: ErrorMessage 로 의도한 건지 확인 필요 */}
           <FormField.ErrorMessage value="주소를 추가하면 가까운 역을 찾아드려요!" />
         </S.FlexVertical>
         {/* 보증금 월세 */}

--- a/frontend/src/components/NewChecklist/NewChecklistInfoTemplate.tsx
+++ b/frontend/src/components/NewChecklist/NewChecklistInfoTemplate.tsx
@@ -6,11 +6,11 @@ import Badge from '@/components/_common/Badge/Badge';
 import Button from '@/components/_common/Button/Button';
 import FormField from '@/components/_common/FormField/FormField';
 import Header from '@/components/_common/Header/Header';
-import { InputChangeEvent } from '@/components/_common/Input/Input';
 import RadioGroup from '@/components/_common/RadioGroup/RadioGroup';
 import { roomFloorLevels, roomStructures, roomTypes } from '@/constants/roomInfo';
 import checklistRoomInfoStore from '@/store/checklistRoomInfoStore';
 import { flexCenter, flexColumn, flexRow } from '@/styles/common';
+import { InputChangeEvent } from '@/types/event';
 import { RoomInfo, RoomInfoName } from '@/types/room';
 
 const NewChecklistInfoTemplate = () => {

--- a/frontend/src/components/_common/FormField/FormField.stories.tsx
+++ b/frontend/src/components/_common/FormField/FormField.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import FormField from '@/components/_common/FormField/FormField';
-import { InputChangeEvent } from '@/components/_common/Input/Input';
+import { InputChangeEvent } from '@/types/event';
 
 const meta = {
   title: 'components/FormField',

--- a/frontend/src/components/_common/FormField/FormField.tsx
+++ b/frontend/src/components/_common/FormField/FormField.tsx
@@ -3,15 +3,8 @@ import { HTMLAttributes } from 'react';
 
 import { InputRequiredDot } from '@/assets/assets';
 import Input from '@/components/_common/Input/Input';
+import { flexColumn } from '@/styles/common';
 import theme from '@/styles/theme';
-
-const FormFieldWrapper = styled.div<{ rowGap?: string }>`
-  display: flex;
-
-  flex: auto;
-  flex-direction: column;
-  row-gap: ${({ rowGap }) => (rowGap ? rowGap : '10px')};
-`;
 
 type GetProps<T> = T extends React.FC<infer P> ? P : never;
 
@@ -19,6 +12,13 @@ interface LabelProps extends HTMLAttributes<HTMLLabelElement> {
   label: string;
   required?: boolean;
 }
+
+const FormFieldWrapper = styled.div<{ rowGap?: string }>`
+  ${flexColumn}
+
+  flex: auto;
+  row-gap: ${({ rowGap }) => (rowGap ? rowGap : '10px')};
+`;
 
 const FormField = Object.assign(FormFieldWrapper, {
   Label: ({ label, required = false, ...rest }: LabelProps) => (
@@ -29,7 +29,7 @@ const FormField = Object.assign(FormFieldWrapper, {
   ),
   Input: ({ ...rest }: GetProps<typeof Input>) => <Input {...rest} />,
   ErrorMessage: ({ value, ...rest }: { value: string } & HTMLAttributes<HTMLParagraphElement>) => (
-    <S.P {...rest}>{value}</S.P>
+    <S.ErrorMessage {...rest}>{value}</S.ErrorMessage>
   ),
 });
 
@@ -39,15 +39,15 @@ const S = {
     top: -15px;
     left: 5px;
   `,
-  P: styled.p`
+  LabelContainer: styled.label`
+    position: relative;
+    z-index: 0;
+  `,
+  ErrorMessage: styled.p`
     height: 10px;
 
     color: black;
     font-size: ${({ theme }) => theme.text.size.small};
-  `,
-  LabelContainer: styled.label`
-    position: relative;
-    z-index: 0;
   `,
 };
 export default FormField;

--- a/frontend/src/components/_common/FormField/FormField.tsx
+++ b/frontend/src/components/_common/FormField/FormField.tsx
@@ -46,8 +46,8 @@ const S = {
   ErrorMessage: styled.p`
     height: 10px;
 
-    color: black;
-    font-size: ${({ theme }) => theme.text.size.small};
+    color: ${({ theme }) => theme.palette.red500};
+    font-size: ${({ theme }) => theme.text.size.xSmall};
   `,
 };
 export default FormField;

--- a/frontend/src/components/_common/Input/Input.tsx
+++ b/frontend/src/components/_common/Input/Input.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
-import { ChangeEvent, useCallback } from 'react';
+import { useCallback } from 'react';
 
-interface StyledProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  $color?: 'string';
-}
+import { flexCenter } from '@/styles/common';
+import { InputChangeEvent } from '@/types/event';
+
 const widthSize = {
   small: '45px',
   medium: '110px',
@@ -26,22 +26,27 @@ const Input = ({ width = 'full', value, onChange, ...rest }: Props) => {
 
   return <S.Input width={widthSize[width]} value={value} {...rest} onChange={handleChange} />;
 };
+
+export default Input;
+
+interface StyledProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  $color?: 'string';
+}
+
 const S = {
   Input: styled.input<StyledProps>`
     ${({ width }) => width && `width: ${width};`};
     height: 32px;
     padding: 6px 11px;
-    border: 1px solid ${({ $color, theme }) => ($color ? $color : theme.palette.grey100)};
-
-    background-color: ${({ theme }) => theme.palette.grey100};
+    border: 1px solid ${({ $color, theme }) => ($color ? $color : theme.palette.grey300)};
+    border-radius: 4px;
 
     color: ${({ $color, theme }) => ($color ? $color : theme.palette.grey600)};
     font-weight: ${({ theme }) => theme.text.weight.medium};
     font-size: ${({ theme }) => theme.text.size.small};
     outline-color: ${({ theme }) => theme.palette.grey300};
-    justify-content: center;
-    align-items: center;
+
+    ${flexCenter}
     box-sizing: border-box;
   `,
 };
-export default Input;

--- a/frontend/src/components/_common/Input/Input.tsx
+++ b/frontend/src/components/_common/Input/Input.tsx
@@ -14,7 +14,6 @@ const widthSize = {
 interface Props extends React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
   width?: keyof typeof widthSize;
 }
-export type InputChangeEvent = ChangeEvent<HTMLInputElement | HTMLTextAreaElement>;
 
 const Input = ({ width = 'full', value, onChange, ...rest }: Props) => {
   const handleChange = useCallback(

--- a/frontend/src/components/_common/Modal/Modal.tsx
+++ b/frontend/src/components/_common/Modal/Modal.tsx
@@ -7,21 +7,11 @@ import { CloseIcon } from '@/assets/assets';
 import ModalBody from '@/components/_common/Modal/ModalBody';
 import ModalFooter from '@/components/_common/Modal/ModalFooter';
 import ModalHeader from '@/components/_common/Modal/ModalHeader';
+import { flexColumn } from '@/styles/common';
 
 type ModalPosition = 'center' | 'bottom';
 
 type ModalSize = 'small' | 'large';
-
-const SIZE_MAP = {
-  small: css`
-    max-width: 300px;
-    width: 75%;
-  `,
-  large: css`
-    max-width: 400px;
-    width: 85%;
-  `,
-};
 
 export interface ModalProps extends ComponentPropsWithRef<'dialog'> {
   isOpen: boolean;
@@ -83,18 +73,15 @@ const S = {
     $position: ModalPosition;
     $size: ModalSize;
   }>`
-    display: flex;
-    flex-direction: column;
+    ${flexColumn}
     align-items: flex-start;
 
     position: fixed;
     left: 50%;
-    ${({ $position }) => positionStyles[$position]}
+    ${({ $position, $size }) => positionStyles[$position]($size)}
 
     min-height: 150px;
     padding: 12px;
-
-    ${({ $size }) => $size && SIZE_MAP[$size]}
 
     background-color: ${({ theme }) => theme.palette.white};
 
@@ -115,18 +102,19 @@ const S = {
 };
 
 const positionStyles = {
-  center: css`
+  center: ($size: ModalSize) => css`
     top: 50%;
     transform: translate(-50%, -50%);
     border-radius: 8px;
-    width: 85%;
+    width: ${$size === 'small' ? '60%' : '85%'};
     max-width: 500px;
   `,
-  bottom: css`
+  bottom: ($size: ModalSize) => css`
     bottom: 0;
     transform: translate(-50%, 0%);
     border-radius: 16px 16px 0 0;
-    width: 100%;
+    width: ${$size && '100%'};
+    max-width: 600px;
     box-sizing: border-box;
   `,
 };

--- a/frontend/src/components/_common/RadioGroup/RadioContext.ts
+++ b/frontend/src/components/_common/RadioGroup/RadioContext.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
-import { InputChangeEvent } from '@/components/_common/Input/Input';
+import { InputChangeEvent } from '@/types/event';
 
 interface RadioState {
   value: string;

--- a/frontend/src/components/_common/RadioGroup/RadioGroup.tsx
+++ b/frontend/src/components/_common/RadioGroup/RadioGroup.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import { HTMLAttributes, useContext } from 'react';
 
-import { InputChangeEvent } from '@/components/_common/Input/Input';
 import RadioContext from '@/components/_common/RadioGroup/RadioContext';
 import { flexCenter, flexRow } from '@/styles/common';
+import { InputChangeEvent } from '@/types/event';
 
 interface Props extends HTMLAttributes<HTMLFieldSetElement> {
   label: string;

--- a/frontend/src/hooks/useInputs.ts
+++ b/frontend/src/hooks/useInputs.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { InputChangeEvent } from '@/components/_common/Input/Input';
+import { InputChangeEvent } from '@/types/event';
 
 const useInputs = <T extends object>(initialValue: T) => {
   const [values, setValues] = useState(initialValue);
@@ -10,8 +10,6 @@ const useInputs = <T extends object>(initialValue: T) => {
       ...prev,
       [event.target.name]: event.target?.type === 'number' ? parseInt(event.target.value) : event.target.value,
     }));
-    console.log(event.target.name, event.target.value);
-    console.log(values);
   };
 
   return { values, onChange, setValues };

--- a/frontend/src/pages/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage.tsx
@@ -91,10 +91,10 @@ const NewChecklistPage = () => {
         center={<Header.Text>{'새 체크리스트'}</Header.Text>}
         right={<Button label={'저장'} size="small" color="dark" onClick={handleSubmitChecklist} />}
       />
-      <TabProvider defaultTab={0}>
-        {/* 체크리스트 작성의 탭 */}
+      <TabProvider defaultTab={-1}>
+        {/* 카테고리 탭 */}
         <NewChecklistTab />
-        {/*체크리스트 콘텐츠 섹션*/}
+        {/* 체크리스트 작성 */}
         <NewChecklistContent />
       </TabProvider>
     </>

--- a/frontend/src/store/checklistRoomInfoStore.ts
+++ b/frontend/src/store/checklistRoomInfoStore.ts
@@ -1,6 +1,6 @@
 import { createStore } from 'zustand';
 
-import { InputChangeEvent } from '@/components/_common/Input/Input';
+import { InputChangeEvent } from '@/types/event';
 import { RoomInfo } from '@/types/room';
 import { isNumericValidator, lengthValidator, nonNegativeValidator, Validator } from '@/utils/validators';
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,12 +1,12 @@
 const palette = {
-  /*yellow*/
+  /* yellow */
   yellow600: '#FFC107',
   yellow500: '#FFDB5D',
   yellow400: '#FFE27D',
   yellow300: '#FFEA9E',
   yellow200: '#FFF1BE',
   yellow100: '#FFF8DF',
-  /*green*/
+  /* green */
   green600: '#22BD6A',
   green500: '#49CE7F',
   green400: '#6DD899',
@@ -14,13 +14,17 @@ const palette = {
   green200: '#B6EBCC',
   green100: '#DBF5E5',
   green50: '#E6F8ED',
-  /*subGreen*/
+  /* subGreen */
   subGreen600: '#8BB26B',
   subGreen500: '#A6CF85',
   subGreen400: '#B8D99E',
   subGreen300: '#CAE2B6',
   subGreen200: '#D3ECAD',
   subGreen100: '#EDF5E7',
+  /* red */
+  red600: '#D9593E',
+  red500: '#FC6A4B',
+  red300: '#FFC7AF',
   /* grey */
   grey600: '#484947',
   grey500: '#7C7C7C',

--- a/frontend/src/types/event.ts
+++ b/frontend/src/types/event.ts
@@ -1,0 +1,3 @@
+import { ChangeEvent } from 'react';
+
+export type InputChangeEvent = ChangeEvent<HTMLInputElement | HTMLTextAreaElement>;


### PR DESCRIPTION
## ❗ Issue

- #330 

## ✨ 구현한 기능

- 인풋 컴포넌트 UI 변경
- 다음 주소 검색 모달 연결 및 상태 연결 완료 
모달에서 검색한 주소가 상태처리가 되어서 인풋 내부에도 보일 수 있게 작업해놨습니다. 

참고 UI
<img width="410" alt="스크린샷 2024-08-13 오전 1 40 10" src="https://github.com/user-attachments/assets/9ca0a79c-cbe5-4751-979b-a844691df246">

 


**추가 변경 사항** 
- 모달 컴포넌트 바뀐 것에 대한 에러가 있어서 수정했습니다. 
- bottom, center, small 모두 확인했으나 혹시 문제있으면 알려주세요 

기존 문제 UI 
<img width="417" alt="스크린샷 2024-08-13 오전 12 49 51" src="https://github.com/user-attachments/assets/6434bee5-c73e-412a-8df7-887332ecfec2">

바꾼 UI
<img width="416" alt="스크린샷 2024-08-13 오전 1 38 27" src="https://github.com/user-attachments/assets/055ddde7-f26b-40eb-b70e-c6abc5e2f101">


## 📢 논의하고 싶은 내용

- 지금 구글 폼 에러 메세지가 작동하고 있는걸까요? 따로 아무런 에러메시지를 확인 할 수 없어서 확인이 필요할거 같습니다. 


## 🎸 기타

