### PR TITLE
[BE] 회원가입시 디폴트 체크리스트를 추가한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/AuthService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/AuthService.java
@@ -2,12 +2,24 @@ package com.bang_ggood.auth.service;
 
 import com.bang_ggood.auth.dto.request.OauthLoginRequest;
 import com.bang_ggood.auth.dto.response.OauthInfoApiResponse;
+import com.bang_ggood.checklist.domain.Answer;
 import com.bang_ggood.checklist.domain.CustomChecklistQuestion;
+import com.bang_ggood.checklist.domain.OccupancyMonth;
+import com.bang_ggood.checklist.domain.OccupancyPeriod;
+import com.bang_ggood.checklist.domain.Option;
 import com.bang_ggood.checklist.domain.Question;
+import com.bang_ggood.checklist.dto.request.ChecklistRequest;
+import com.bang_ggood.checklist.dto.request.QuestionRequest;
 import com.bang_ggood.checklist.repository.CustomChecklistQuestionRepository;
+import com.bang_ggood.checklist.service.ChecklistService;
+import com.bang_ggood.room.domain.FloorLevel;
+import com.bang_ggood.room.domain.Structure;
+import com.bang_ggood.room.domain.Type;
+import com.bang_ggood.room.dto.request.RoomRequest;
 import com.bang_ggood.user.domain.User;
 import com.bang_ggood.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
@@ -15,17 +27,21 @@ public class AuthService {
 
     private final OauthClient oauthClient;
     private final JwtTokenProvider jwtTokenProvider;
+    private final ChecklistService checklistService;
     private final UserRepository userRepository;
     private final CustomChecklistQuestionRepository customChecklistQuestionRepository;
 
-    public AuthService(OauthClient oauthClient, JwtTokenProvider jwtTokenProvider, UserRepository userRepository,
+    public AuthService(OauthClient oauthClient, JwtTokenProvider jwtTokenProvider, ChecklistService checklistService,
+                       UserRepository userRepository,
                        CustomChecklistQuestionRepository customChecklistQuestionRepository) {
         this.oauthClient = oauthClient;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.checklistService = checklistService;
         this.userRepository = userRepository;
         this.customChecklistQuestionRepository = customChecklistQuestionRepository;
     }
 
+    @Transactional
     public String login(OauthLoginRequest request) {
         OauthInfoApiResponse oauthInfoApiResponse = oauthClient.requestOauthInfo(request);
 
@@ -38,6 +54,7 @@ public class AuthService {
     private User signUp(OauthInfoApiResponse oauthInfoApiResponse) {
         User user = userRepository.save(oauthInfoApiResponse.toUserEntity());
         createDefaultChecklistQuestions(user);
+        createDefaultChecklist(user);
         return user;
     }
 
@@ -48,6 +65,32 @@ public class AuthService {
                 .toList();
 
         customChecklistQuestionRepository.saveAll(checklistQuestions);
+    }
+
+    private void createDefaultChecklist(User user) {
+        RoomRequest roomRequest = new RoomRequest(
+                "예시용 체크리스트", 2000, 50, 12, "서울특별시 송파구",
+                "잠실역", 10, "방끗 부동산", Type.VILLA.getName(), Structure.OPEN_ONE_ROOM.getName(),
+                5.0, 2, FloorLevel.GROUND.getName(), OccupancyMonth.SEPTEMBER.getMonth(), OccupancyPeriod.EARLY.getPeriod(),
+                "집을 둘러보며 필요한 메모를 작성해보세요.", "한줄평 작성하는 곳");
+
+        List<Integer> options = List.of(
+                Option.TV.getId(),
+                Option.AIR_CONDITIONER.getId(),
+                Option.SINK.getId(),
+                Option.BED.getId());
+
+        List<QuestionRequest> questionRequests = List.of(
+                new QuestionRequest(Question.ROOM_CONDITION_1.getId(), Answer.GOOD.name()),
+                new QuestionRequest(Question.ROOM_CONDITION_2.getId(), Answer.BAD.name()),
+                new QuestionRequest(Question.ROOM_CONDITION_3.getId(), Answer.GOOD.name()),
+                new QuestionRequest(Question.WINDOW_1.getId(), Answer.GOOD.name()),
+                new QuestionRequest(Question.WINDOW_2.getId(), Answer.BAD.name()),
+                new QuestionRequest(Question.BATHROOM_1.getId(), Answer.GOOD.name()),
+                new QuestionRequest(Question.BATHROOM_2.getId(), Answer.GOOD.name()));
+
+        ChecklistRequest checklistRequest = new ChecklistRequest(roomRequest, options, questionRequests);
+        checklistService.createChecklist(user, checklistRequest);
     }
 
     public User extractUser(String token) {

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/domain/Option.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/domain/Option.java
@@ -43,6 +43,10 @@ public enum Option {
         throw new BangggoodException(ExceptionCode.OPTION_INVALID);
     }
 
+    public int getId() {
+        return id;
+    }
+
     public String getName() {
         return name;
     }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/auth/service/AuthServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/auth/service/AuthServiceTest.java
@@ -2,7 +2,13 @@ package com.bang_ggood.auth.service;
 
 import com.bang_ggood.IntegrationTestSupport;
 import com.bang_ggood.auth.dto.request.OauthLoginRequest;
+import com.bang_ggood.category.dto.response.CategoryQuestionsResponse;
+import com.bang_ggood.checklist.domain.Question;
+import com.bang_ggood.checklist.dto.response.ChecklistQuestionsResponse;
+import com.bang_ggood.checklist.dto.response.UserChecklistsPreviewResponse;
+import com.bang_ggood.checklist.service.ChecklistService;
 import com.bang_ggood.user.UserFixture;
+import com.bang_ggood.user.domain.User;
 import com.bang_ggood.user.repository.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +30,8 @@ class AuthServiceTest extends IntegrationTestSupport {
     private OauthClient oauthClient;
     @Autowired
     private AuthService authService;
+    @Autowired
+    private ChecklistService checklistService;
     @Autowired
     private UserRepository userRepository;
 
@@ -54,5 +62,43 @@ class AuthServiceTest extends IntegrationTestSupport {
 
         // then
         Assertions.assertThat(token).isNotBlank();
+    }
+
+    @DisplayName("로그인 성공 : 회원 가입시 디폴트 체크리스트 질문을 추가한다.")
+    @Test
+    void login_default_checklist_question() {
+        // given
+        Mockito.when(oauthClient.requestOauthInfo(any(OauthLoginRequest.class)))
+                .thenReturn(UserFixture.OAUTH_INFO_RESPONSE_USER2);
+
+        // when
+        String token = authService.login(oauthLoginRequest);
+
+        // then
+        User user = authService.extractUser(token);
+        ChecklistQuestionsResponse checklistQuestions = checklistService.readChecklistQuestions(user);
+
+        int sum = 0;
+        for (CategoryQuestionsResponse response: checklistQuestions.categories()) {
+            sum += response.questions().size();
+        }
+
+        Assertions.assertThat(sum).isEqualTo(Question.findDefaultQuestions().size());
+    }
+
+    @DisplayName("로그인 성공 : 회원 가입시 디폴트 체크리스트를 추가한다.")
+    @Test
+    void login_default_checklist() {
+        // given
+        Mockito.when(oauthClient.requestOauthInfo(any(OauthLoginRequest.class)))
+                .thenReturn(UserFixture.OAUTH_INFO_RESPONSE_USER2);
+
+        // when
+        String token = authService.login(oauthLoginRequest);
+
+        // then
+        User user = authService.extractUser(token);
+        UserChecklistsPreviewResponse response = checklistService.readUserChecklistsPreview(user);
+        Assertions.assertThat(response.checklists()).hasSize(1);
     }
 }


### PR DESCRIPTION
## ❗ Issue

- #349 

## ✨ 구현한 기능

- 회원가입시 디폴트 체크리스트 추가

## 📢 논의하고 싶은 내용


**논의사항1**
모든 유저에게 보일 예시용 체크리스트여서 처음에는 데이터베이스에 저장해두고 쓰는 방식을 고민했는데요,
다음의 이유들로 힘들다고 판단했습니다.

- 어드민 유저 계정이 필요한데 현재는 CD 과정에서 테이블이 드랍된다. 계속해서 어드민 유저를 추가해주어야 한다.
- 다른 방법으로는 Data.sql에 어드민 계정을 추가할 수 있지만, 어드민 계정이 깃헙에 노출된다. 

그래서 현재는 유저가 회원가입할 때마다 디폴트 체크리스트를 추가하는 방식으로 구현했습니다.

**논의사항2**
체크리스트를 생성하기 위해 AuthService가 ChecklistService와 의존성을 갖게 되었는데요, 하나의 메서드를 사용하기 위해
ChecklistService의 모든 퍼블릭 메서드에 접근할 수 있도록하는 것이 올바른 방법인지 모르겠습니다 🥲

## 🎸 기타
