### PR TITLE
[FE] 체크리스트 수정페이지에서 방이름이 비어있을때 버그를 해결한다.

### DIFF
--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/useDefaultRoomName.ts
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/useDefaultRoomName.ts
@@ -10,18 +10,31 @@ const useDefaultRoomName = () => {
 
   const { data: checklistList } = useGetChecklistListQuery();
 
+  // 처음에 빈문자열 설정은 폼에도 적용.
   useEffect(() => {
     if (!checklistList) return;
+    if (roomName !== initialRoomInfo.roomName) return;
 
     const count = checklistList.filter(
       checklist => new Date(checklist.createdAt).getUTCDay() === new Date().getUTCDay(),
     ).length;
 
-    if (roomName !== initialRoomInfo.roomName) return;
-
     const date = new Date();
     actions.set('roomName', `${date.getMonth() + 1}월 ${date.getDate()}일 ${count}번째 방`);
   }, [checklistList]);
+
+  // 그이후부터는 폼은 안건드리고, 내부 value에만 적용
+  useEffect(() => {
+    if (!checklistList) return;
+    if (roomName !== initialRoomInfo.roomName) return;
+
+    const count = checklistList.filter(
+      checklist => new Date(checklist.createdAt).getUTCDay() === new Date().getUTCDay(),
+    ).length;
+
+    const date = new Date();
+    actions.setValueForced('roomName', `${date.getMonth() + 1}월 ${date.getDate()}일 ${count}번째 방`);
+  }, [checklistList, roomName]);
 };
 
 export default useDefaultRoomName;

--- a/frontend/src/pages/EditChecklistPage.tsx
+++ b/frontend/src/pages/EditChecklistPage.tsx
@@ -61,7 +61,7 @@ const EditChecklistPage = () => {
   }, [checklistId]);
 
   // TODO: fetch 시 로딩 상태일 때 스켈레톤처리. 성공할 떄만 return 문 보여주는 로직이 필요
-  if (!roomName) {
+  if (roomName === undefined) {
     return <div>체크리스트가 없어요</div>;
   }
 

--- a/frontend/src/store/createFormStore.ts
+++ b/frontend/src/store/createFormStore.ts
@@ -13,6 +13,7 @@ const initialErrorMessages = <T extends object>(initial: Partial<T>) =>
 interface FormAction<T> {
   onChange: (event: InputChangeEvent) => void;
   set: (name: keyof T, value: string | undefined) => void;
+  setValueForced: (name: string, value: string | number) => void;
   setAll: (state: Partial<FormState<T>>) => void;
   resetAll: () => void;
   _reset: (name: keyof T) => void;
@@ -41,9 +42,7 @@ const createFormStore = <T extends object>(
         value: transformAll(initialRaw, valueType),
         errorMessage: initialErrorMessages(initialRaw),
         actions: {
-          onChange: event => {
-            get().actions.set(event.target.name as keyof T, event.target.value);
-          },
+          onChange: event => get().actions.set(event.target.name as keyof T, event.target.value),
           set: (name, value) => {
             if (value === '') {
               get().actions._reset(name);
@@ -52,6 +51,7 @@ const createFormStore = <T extends object>(
 
             get().actions._updateAfterValidation(name, value ?? '', validatorSet[name as string]);
           },
+          setValueForced: (name, value) => set({ value: { ...get().value, [name]: value } }),
 
           resetAll: () =>
             set({

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -27,6 +27,7 @@ const config = {
   entry: './src/index.tsx',
   output: {
     path: path.resolve(__dirname, 'dist'),
+    clean: true,
   },
   devServer: {
     open: true,


### PR DESCRIPTION
## ❗ Issue

- #484

## ✨ 구현한 기능
체크리스트 수정페이지에서 방이름이 비어있을때 버그를 해결한다.
방이름을 다지웠을때 전송눌러도 N번째방이 채워서 put 보내진다. (edit페이지에는 적용하지않는다.)

## 📢 논의하고 싶은 내용



## 🎸 기타

