### PR TITLE
[FE] 폼 입력시 모든 인풋 컴포넌트가 재랜더되는 것을 막는다. 

### DIFF
--- a/frontend/src/components/NewChecklist/SummaryModal/SummaryModal.tsx
+++ b/frontend/src/components/NewChecklist/SummaryModal/SummaryModal.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 import { useStore } from 'zustand';
 
 import Button from '@/components/_common/Button/Button';
@@ -6,17 +7,31 @@ import CounterBox from '@/components/_common/CounterBox/CounterBox';
 import FormField from '@/components/_common/FormField/FormField';
 import Modal from '@/components/_common/Modal/Modal';
 import { MODAL_MESSAGE } from '@/constants/message';
+import { ROUTE_PATH } from '@/constants/routePath';
+import useMutateChecklist from '@/hooks/useMutateChecklist';
 import checklistRoomInfoStore from '@/store/checklistRoomInfoStore';
 import { flexColumn, title3 } from '@/styles/common';
+import { MutateType } from '@/types/checklist';
 
 interface Props {
   isModalOpen: boolean;
   modalClose: () => void;
-  submitChecklist: () => void;
+  mutateType: MutateType;
+  checklistId?: number;
 }
 
-const SummaryModal = ({ isModalOpen, modalClose, submitChecklist }: Props) => {
+const SummaryModal = ({ isModalOpen, modalClose, mutateType, checklistId }: Props) => {
+  const navigate = useNavigate();
   const { rawValue: roomInfo, actions } = useStore(checklistRoomInfoStore);
+
+  // 체크리스트 작성 / 수정
+  const { handleSubmitChecklist } = useMutateChecklist(mutateType, checklistId);
+
+  const handleCloseModal = () => {
+    handleSubmitChecklist();
+    modalClose();
+    navigate(ROUTE_PATH.checklistList);
+  };
 
   return (
     <Modal isOpen={isModalOpen} onClose={modalClose}>
@@ -37,7 +52,7 @@ const SummaryModal = ({ isModalOpen, modalClose, submitChecklist }: Props) => {
           <S.CounterContainer>
             <CounterBox currentCount={roomInfo.summary?.length || 0} totalCount={15} />
           </S.CounterContainer>
-          <Button size="full" color="dark" onClick={submitChecklist} isSquare label="체크리스트 저장하기" />
+          <Button size="full" color="dark" onClick={handleCloseModal} isSquare label="체크리스트 저장하기" />
         </S.Wrapper>
       </Modal.body>
     </Modal>

--- a/frontend/src/hooks/useMutateChecklist.ts
+++ b/frontend/src/hooks/useMutateChecklist.ts
@@ -1,21 +1,19 @@
-import { useNavigate } from 'react-router-dom';
 import { useStore } from 'zustand';
 
-import { ROUTE_PATH } from '@/constants/routePath';
 import useAddChecklistQuery from '@/hooks/query/useAddChecklistQuery';
+import usePutChecklistQuery from '@/hooks/query/usePutCheclistQuery';
 import useToast from '@/hooks/useToast';
 import checklistAddressStore from '@/store/checklistAddressStore';
 import checklistIncludedMaintenancesStore from '@/store/checklistIncludedMaintenancesStore';
 import checklistRoomInfoStore from '@/store/checklistRoomInfoStore';
 import useChecklistStore from '@/store/useChecklistStore';
 import useOptionStore from '@/store/useOptionStore';
-import { ChecklistCategoryQnA } from '@/types/checklist';
+import { ChecklistCategoryQnA, MutateType } from '@/types/checklist';
 
-const useChecklistPost = (summaryModalClose: () => void) => {
+const useMutateChecklist = (mutateType: MutateType, checklistId?: number) => {
   const { showToast } = useToast({ type: 'positive' });
   const { mutate: addChecklist } = useAddChecklistQuery();
-
-  const navigate = useNavigate();
+  const { mutate: putChecklist } = usePutChecklistQuery();
 
   // 방 기본 정보
   const { value: roomInfoAnswer, actions } = useStore(checklistRoomInfoStore);
@@ -27,33 +25,52 @@ const useChecklistPost = (summaryModalClose: () => void) => {
 
   // 선택된 옵션
   const selectedOptions = useOptionStore(state => state.selectedOptions);
-
   // 체크리스트 답변
   const checklistCategoryQnA = useChecklistStore(state => state.checklistCategoryQnA);
 
-  const handleSubmitChecklist = () => {
-    const postData = {
-      room: { ...roomInfoAnswer, address, buildingName, ...{ includedMaintenances: includedMaintenances.value } },
+  const postData = {
+    room: { ...roomInfoAnswer, address, buildingName, ...{ includedMaintenances: includedMaintenances.value } },
+    options: selectedOptions,
+    questions: transformQuestions(checklistCategoryQnA),
+  };
+
+  const putData = {
+    id: Number(checklistId),
+    checklist: {
+      room: roomInfoAnswer,
       options: selectedOptions,
       questions: transformQuestions(checklistCategoryQnA),
-    };
+    },
+  };
 
+  const handleSubmitChecklist = () => {
     const fetchNewChecklist = () => {
       addChecklist(postData, {
         onSuccess: () => {
-          summaryModalClose();
           showToast('체크리스트가 저장되었습니다.'); // TODO: 메세지 상수처리
           actions.resetAll();
-          navigate(ROUTE_PATH.checklistList);
         },
       });
     };
 
-    fetchNewChecklist();
+    const putEditedChecklist = () => {
+      putChecklist(putData, {
+        onSuccess: () => {
+          showToast('체크리스트가 수정되었습니다.'); // TODO: 메세지 상수처리
+          actions.resetAll();
+        },
+      });
+    };
+
+    mutateType === 'add' && fetchNewChecklist();
+    mutateType === 'edit' && putEditedChecklist();
   };
 
   return { handleSubmitChecklist };
 };
+
+export default useMutateChecklist;
+
 // 현재 상태를 백엔드에 보내는 답안 포맷으로 바꾸는 함수
 const transformQuestions = (checklist: ChecklistCategoryQnA[]) => {
   return checklist.flatMap(category =>
@@ -63,5 +80,3 @@ const transformQuestions = (checklist: ChecklistCategoryQnA[]) => {
     })),
   );
 };
-
-export default useChecklistPost;

--- a/frontend/src/hooks/useMutateChecklist.ts
+++ b/frontend/src/hooks/useMutateChecklist.ts
@@ -44,7 +44,7 @@ const useMutateChecklist = (mutateType: MutateType, checklistId?: number) => {
   };
 
   const handleSubmitChecklist = () => {
-    const fetchNewChecklist = () => {
+    const postNewChecklist = () => {
       addChecklist(postData, {
         onSuccess: () => {
           showToast('체크리스트가 저장되었습니다.'); // TODO: 메세지 상수처리
@@ -62,7 +62,7 @@ const useMutateChecklist = (mutateType: MutateType, checklistId?: number) => {
       });
     };
 
-    mutateType === 'add' && fetchNewChecklist();
+    mutateType === 'add' && postNewChecklist();
     mutateType === 'edit' && putEditedChecklist();
   };
 

--- a/frontend/src/pages/EditChecklistPage.tsx
+++ b/frontend/src/pages/EditChecklistPage.tsx
@@ -1,6 +1,4 @@
-import { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { useStore } from 'zustand';
+import { useParams } from 'react-router-dom';
 
 import Button from '@/components/_common/Button/Button';
 import Header from '@/components/_common/Header/Header';
@@ -10,97 +8,21 @@ import MemoButton from '@/components/NewChecklist/MemoModal/MemoButton';
 import MemoModal from '@/components/NewChecklist/MemoModal/MemoModal';
 import NewChecklistContent from '@/components/NewChecklist/NewChecklistContent';
 import SummaryModal from '@/components/NewChecklist/SummaryModal/SummaryModal';
-import { ROUTE_PATH } from '@/constants/routePath';
 import { DEFAULT_CHECKLIST_TAB_PAGE } from '@/constants/system';
-import useGetChecklistDetailQuery from '@/hooks/query/useGetChecklistDetailQuery';
-import usePutChecklistQuery from '@/hooks/query/usePutCheclistQuery';
 import useModalOpen from '@/hooks/useModalOpen';
 import useNewChecklistTabs from '@/hooks/useNewChecklistTabs';
-import useToast from '@/hooks/useToast';
-import checklistIncludedMaintenancesStore from '@/store/checklistIncludedMaintenancesStore';
-import checklistRoomInfoStore from '@/store/checklistRoomInfoStore';
-import useChecklistStore from '@/store/useChecklistStore';
-import useOptionStore from '@/store/useOptionStore';
-import { ChecklistCategoryQnA } from '@/types/checklist';
-import { objectOmit } from '@/utils/typeFunctions';
 
 type RouteParams = {
   checklistId: string;
 };
+
 const EditChecklistPage = () => {
-  const navigate = useNavigate();
-  const { showToast } = useToast();
+  const { checklistId } = useParams() as RouteParams;
+
   const { tabs } = useNewChecklistTabs();
 
-  const { isModalOpen, modalOpen, modalClose } = useModalOpen();
+  const { isModalOpen, modalOpen, modalClose } = useModalOpen(); // 한줄평 모달
   const { isModalOpen: isMemoModalOpen, modalOpen: memoModalOpen, modalClose: memoModalClose } = useModalOpen(); // 메모 모달
-
-  const { checklistId } = useParams() as RouteParams;
-  const { data: checklist, isSuccess } = useGetChecklistDetailQuery(checklistId);
-  const { mutate: putChecklist } = usePutChecklistQuery();
-
-  /* roomInfo */
-  const roomInfoAnswer = useStore(checklistRoomInfoStore, state => state.value);
-  const actions = useStore(checklistRoomInfoStore, state => state.actions);
-  const roomName = useStore(checklistRoomInfoStore, state => state.value.roomName);
-  const IncludedMaintenancesActions = useStore(checklistIncludedMaintenancesStore, state => state.actions);
-
-  /* option */
-  const { selectedOptions, setSelectedOptions } = useOptionStore();
-  /* checklist */
-  const { checklistCategoryQnA, setAnswers } = useChecklistStore();
-
-  useEffect(() => {
-    const fetchChecklistAndSetToStore = async () => {
-      if (!isSuccess) return;
-      actions.setAll({ rawValue: objectOmit(checklist.room, new Set('includedMaintenances')), value: checklist.room });
-      IncludedMaintenancesActions.set(checklist.room.includedMaintenances ?? []);
-      setSelectedOptions(checklist.options.flatMap(option => option.optionId));
-
-      setAnswers(checklist.categories);
-    };
-    fetchChecklistAndSetToStore();
-  }, [checklistId]);
-
-  // TODO: fetch 시 로딩 상태일 때 스켈레톤처리. 성공할 떄만 return 문 보여주는 로직이 필요
-  if (roomName === undefined) {
-    return <div>체크리스트가 없어요</div>;
-  }
-
-  /* 현재 상태를 백엔드에 보내는 답안 포맷으로 바꾸는 함수 */
-  const transformQuestions = (checklist: ChecklistCategoryQnA[]) => {
-    return checklist.flatMap(category =>
-      category.questions.map(question => ({
-        questionId: question.questionId,
-        answer: question.answer,
-      })),
-    );
-  };
-
-  const handleSubmitChecklist = () => {
-    const fetchNewChecklist = () => {
-      putChecklist(
-        {
-          id: Number(checklistId),
-          checklist: {
-            room: roomInfoAnswer,
-            options: selectedOptions,
-            questions: transformQuestions(checklistCategoryQnA),
-          },
-        },
-        {
-          onSuccess: () => {
-            modalClose();
-            showToast('체크리스트가 수정되었습니다.');
-            actions.resetAll();
-            navigate(ROUTE_PATH.checklistOne(Number(checklistId)));
-          },
-        },
-      );
-    };
-
-    fetchNewChecklist();
-  };
 
   return (
     <>
@@ -122,9 +44,15 @@ const EditChecklistPage = () => {
       ) : (
         <MemoButton onClick={memoModalOpen} />
       )}
+
       {/* 한줄평 모달*/}
       {isModalOpen && (
-        <SummaryModal isModalOpen={isModalOpen} modalClose={modalClose} submitChecklist={handleSubmitChecklist} />
+        <SummaryModal
+          isModalOpen={isModalOpen}
+          modalClose={modalClose}
+          mutateType="edit"
+          checklistId={Number(checklistId)}
+        />
       )}
     </>
   );

--- a/frontend/src/pages/EditChecklistPage.tsx
+++ b/frontend/src/pages/EditChecklistPage.tsx
@@ -18,18 +18,24 @@ type RouteParams = {
 
 const EditChecklistPage = () => {
   const { checklistId } = useParams() as RouteParams;
-
   const { tabs } = useNewChecklistTabs();
 
-  const { isModalOpen, modalOpen, modalClose } = useModalOpen(); // 한줄평 모달
-  const { isModalOpen: isMemoModalOpen, modalOpen: memoModalOpen, modalClose: memoModalClose } = useModalOpen(); // 메모 모달
+  // 한줄평 모달
+  const {
+    isModalOpen: isSummaryModalOpen,
+    modalOpen: summaryModalOpen,
+    modalClose: summaryModalClose,
+  } = useModalOpen();
+
+  // 메모 모달
+  const { isModalOpen: isMemoModalOpen, modalOpen: memoModalOpen, modalClose: memoModalClose } = useModalOpen();
 
   return (
     <>
       <Header
         left={<Header.Backward />}
         center={<Header.Text>체크리스트 편집</Header.Text>}
-        right={<Button label="저장" size="small" color="dark" onClick={modalOpen} />}
+        right={<Button label="저장" size="small" color="dark" onClick={summaryModalOpen} />}
       />
       <TabProvider defaultTab={DEFAULT_CHECKLIST_TAB_PAGE}>
         {/* 체크리스트 작성의 탭 */}
@@ -46,10 +52,10 @@ const EditChecklistPage = () => {
       )}
 
       {/* 한줄평 모달*/}
-      {isModalOpen && (
+      {isSummaryModalOpen && (
         <SummaryModal
-          isModalOpen={isModalOpen}
-          modalClose={modalClose}
+          isModalOpen={isSummaryModalOpen}
+          modalClose={summaryModalClose}
           mutateType="edit"
           checklistId={Number(checklistId)}
         />

--- a/frontend/src/pages/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage.tsx
@@ -12,7 +12,6 @@ import NewChecklistContent from '@/components/NewChecklist/NewChecklistContent';
 import SummaryModal from '@/components/NewChecklist/SummaryModal/SummaryModal';
 import { ROUTE_PATH } from '@/constants/routePath';
 import { DEFAULT_CHECKLIST_TAB_PAGE } from '@/constants/system';
-import useChecklistPost from '@/hooks/useChecklistPost';
 import useChecklistTemplate from '@/hooks/useInitialChecklist';
 import useModalOpen from '@/hooks/useModalOpen';
 import useNewChecklistTabs from '@/hooks/useNewChecklistTabs';
@@ -33,9 +32,6 @@ const NewChecklistPage = () => {
     modalOpen: summaryModalOpen,
     modalClose: summaryModalClose,
   } = useModalOpen();
-
-  // 체크리스트 POST
-  const { handleSubmitChecklist } = useChecklistPost(summaryModalClose);
 
   const actions = useStore(checklistRoomInfoStore, state => state.actions);
 
@@ -81,11 +77,7 @@ const NewChecklistPage = () => {
       )}
 
       {isSummaryModalOpen && (
-        <SummaryModal
-          isModalOpen={isSummaryModalOpen}
-          modalClose={summaryModalClose}
-          submitChecklist={handleSubmitChecklist}
-        />
+        <SummaryModal isModalOpen={isSummaryModalOpen} modalClose={summaryModalClose} mutateType="add" />
       )}
     </>
   );

--- a/frontend/src/types/checklist.ts
+++ b/frontend/src/types/checklist.ts
@@ -94,3 +94,5 @@ export interface ChecklistPostForm {
   options: number[];
   questions: AnswerPostForm[];
 }
+
+export type MutateType = 'add' | 'edit';


### PR DESCRIPTION
## ❗ Issue

- #565 

## ✨ 구현한 기능

- 기존 문제였던 인풋 폼 하나의 변동사항이 발생할 때 (인풋이 들어올 때) 페이지 내부에 모든 컴포넌트가 재랜더되는 버그가 있었습니다. 
문제 발생 요인은 페이지에서 포스트 요청을 위해 스토어를 구독하고 있어 발생한 문제로 판단 

해당 스토어를 요청을 보내는 서머리 작성 모달 내부로 이동 시켰습니다. 


**변경 후 랜더되는 모습** 
<img width="687" alt="스크린샷 2024-09-09 오후 2 15 35" src="https://github.com/user-attachments/assets/1161accc-dd22-4235-be66-72c6450c234a">


## 📢 논의하고 싶은 내용



## 🎸 기타

