### PR TITLE
[FE] 환경 변수를 분리하고 모드를 스크립트 명령어로 쓸 수 있도록 수정한다. 

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,10 @@ logs
 node_modules
 dist
 .env
+.env.*
+.env.msw
+.env.production
+.env.development
 
 stories
 *storybook.log

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "main": "index.tsx",
   "license": "MIT",
   "scripts": {
-    "build": "webpack --mode=production --node-env=production",
+    "build": "cross-env NODE_ENV=production API_ENV=production webpack --mode=production",
     "prod": "cross-env NODE_ENV=production API_ENV=production webpack serve --mode=production --open",
     "dev": "cross-env NODE_ENV=development API_ENV=development webpack serve --mode=development --open",
     "msw": "cross-env NODE_ENV=development API_ENV=msw webpack serve --mode=development --open",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,19 +5,17 @@
   "license": "MIT",
   "scripts": {
     "build": "webpack --mode=production --node-env=production",
-    "build:dev": "webpack --mode=development",
-    "build:prod": "webpack --mode=production --node-env=production",
-    "start": "webpack serve --mode=production --open --node-env=production",
-    "watch": "webpack --watch",
-    "dev": "webpack serve",
+    "prod": "cross-env NODE_ENV=production API_ENV=production webpack serve --mode=production --open",
+    "dev": "cross-env NODE_ENV=development API_ENV=development webpack serve --mode=development --open",
+    "msw": "cross-env NODE_ENV=development API_ENV=msw webpack serve --mode=development --open",
+    "init-msw": "msw init public/ --save",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "concurrently --names ,[TYPE] --prefix {name} \"jest\" \"tsc --noEmit\"",
     "postinstall": "cd .. && husky frontend/.husky",
     "format": "prettier --cache --write .",
     "lint": "eslint --cache .",
-    "lint:styled": "stylelint --cache --fix ./*",
-    "msw": "msw init public/ --save"
+    "lint:styled": "stylelint --cache --fix ./*"
   },
   "dependencies": {
     "@emotion/react": "^11.11.4",
@@ -69,6 +67,7 @@
     "@webpack-cli/generators": "^3.0.7",
     "chromatic": "^11.5.6",
     "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "css-loader": "^7.1.2",
     "esbuild": "^0.23.0",
     "esbuild-jest": "^0.5.0",

--- a/frontend/src/apis/config.ts
+++ b/frontend/src/apis/config.ts
@@ -1,1 +1,1 @@
-export const API_URL = process.env.DEV_MODE === 'dev' ? process.env.API_URL_DEV : process.env.API_URL;
+export const API_URL = process.env.API_URL;

--- a/frontend/src/components/NewChecklist/AddressModal/DaumAddressModal.tsx
+++ b/frontend/src/components/NewChecklist/AddressModal/DaumAddressModal.tsx
@@ -68,7 +68,6 @@ const DaumAddressModal = () => {
       <Modal position="bottom" isOpen={isModalOpen} onClose={closeModal}>
         <Modal.header>주소 검색</Modal.header>
         <Modal.body>
-          <S.EmptyBox />
           <div ref={postcodeContainerRef} style={{ width: '100%', marginTop: '1rem' }} />
         </Modal.body>
       </Modal>

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/NearTransportation.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/NearTransportation.tsx
@@ -17,7 +17,7 @@ const NearTransportation = () => {
       {station ? (
         <FormStyled.FieldBox>{`${station}역까지 도보 ${walkingTime}분`}</FormStyled.FieldBox>
       ) : (
-        <FormField.TextBox text={'보신 방과 가장 가까운 지하철역을 찾아드릴게요.'} />
+        <FormField.TextBox text={'보신 방과 가까운 지하철역을 찾아드릴게요.'} />
       )}
 
       <FormField.ErrorMessage value={errorMessageStation || errorMessageWalkingTime || ''} />

--- a/frontend/src/constants/oAuth.ts
+++ b/frontend/src/constants/oAuth.ts
@@ -1,4 +1,4 @@
 const CLIENT_ID = process.env.CLIENT_ID;
-const REDIRECT_URI = process.env.DEV_MODE === 'dev' ? process.env.REDIRECT_URI_DEV : process.env.REDIRECT_URI;
+const REDIRECT_URI = process.env.REDIRECT_URI;
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&response_type=code&prompt=login`;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -7,7 +7,7 @@ import ReactDOM from 'react-dom/client';
 import App from '@/App';
 
 async function enableMocking() {
-  if (process.env.DEV_MODE !== 'on') {
+  if (process.env.API_ENV !== 'msw') {
     return;
   }
   const { worker } = await import('./mocks/browser');

--- a/frontend/src/mocks/fixtures/subway.ts
+++ b/frontend/src/mocks/fixtures/subway.ts
@@ -1,0 +1,12 @@
+export const nearSubway = [
+  {
+    name: '잠실',
+    line: ['8호선', '2호선'],
+    walkingTime: 10,
+  },
+  {
+    name: '선릉역',
+    line: ['2호선', '수인분당선'],
+    walkingTime: 12,
+  },
+];

--- a/frontend/src/mocks/handlers/subway.ts
+++ b/frontend/src/mocks/handlers/subway.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from 'msw';
+
+import { BASE_URL, ENDPOINT } from '@/apis/url';
+import { nearSubway } from '@/mocks/fixtures/subway';
+
+export const SubwayHandlers = [
+  http.get(BASE_URL + ENDPOINT.SUBWAY({ lat: 0, lon: 0 }), () => {
+    return HttpResponse.json(nearSubway, { status: 200 });
+  }),
+];

--- a/frontend/src/routers/router.tsx
+++ b/frontend/src/routers/router.tsx
@@ -14,10 +14,11 @@ import MainPage from '@/pages/MainPage';
 import MyPage from '@/pages/MyPage';
 import NewChecklistPage from '@/pages/NewChecklistPage';
 import NotFound from '@/pages/NotFound';
+import AuthGuard from '@/routers/AuthGuard';
 
 const router = createBrowserRouter([
   {
-    //element: <AuthGuard />,
+    element: <AuthGuard />,
     errorElement: <ErrorPage />,
     children: [
       {

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,27 +1,32 @@
-// Generated using webpack-cli https://github.com/webpack/webpack-cli
-
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WorkboxWebpackPlugin = require('workbox-webpack-plugin');
-const fs = require('fs');
-
-// env
+const { merge } = require('webpack-merge');
 const dotenv = require('dotenv');
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const env = dotenv.config().parsed;
-const isProduction = process.env.NODE_ENV == 'production';
 
+// 공통 환경 변수 로드
+const commonEnv = dotenv.config({ path: path.resolve(__dirname, '.env') }).parsed || {};
+
+// API 모드에 따른 환경 변수 파일 로드
+const apiEnv = process.env.API_ENV;
+const envFilePath = `.env.${apiEnv}`;
+const specificEnv = dotenv.config({ path: path.resolve(__dirname, envFilePath) }).parsed || {};
+
+// 공통 환경 변수와 특정 환경 변수를 병합
+const env = merge(commonEnv, specificEnv);
+
+const isProduction = process.env.NODE_ENV === 'production';
 const stylesHandler = isProduction ? MiniCssExtractPlugin.loader : 'style-loader';
 
-const envKeys = env
-  ? Object.keys(env).reduce((prev, next) => {
-      prev[`process.env.${next}`] = JSON.stringify(env[next]);
-      return prev;
-    }, {})
-  : {};
+// 환경 변수를 Webpack DefinePlugin에 적용할 형태로 변환
+const envKeys = Object.keys(env).reduce((prev, next) => {
+  prev[`process.env.${next}`] = JSON.stringify(env[next]);
+  return prev;
+}, {});
 
 const config = {
   entry: './src/index.tsx',
@@ -66,9 +71,7 @@ const config = {
             loader: 'html-loader',
             options: {
               postprocessor: (content, loaderContext) => {
-                // When you environment supports template literals (using browserslist or options) we will generate code using them
                 const isTemplateLiteralSupported = content[0] === '`';
-
                 return content
                   .replace(/<%=/g, isTemplateLiteralSupported ? `\${` : '" +')
                   .replace(/%>/g, isTemplateLiteralSupported ? '}' : '+ "');
@@ -129,22 +132,25 @@ module.exports = () => {
     config.mode = 'production';
 
     config.plugins.push(new MiniCssExtractPlugin());
-
     config.plugins.push(new WorkboxWebpackPlugin.GenerateSW());
-    config.plugins.push(
-      sentryWebpackPlugin({
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        org: process.env.SENTRY_ORG,
-        project: process.env.SENTRY_PROJECT,
-      }),
-    );
+
+    if (process.env.SENTRY_AUTH_TOKEN) {
+      config.plugins.push(
+        sentryWebpackPlugin({
+          authToken: process.env.SENTRY_AUTH_TOKEN,
+          org: process.env.SENTRY_ORG,
+          project: process.env.SENTRY_PROJECT,
+        }),
+      );
+    }
+
     config.devtool = 'source-map';
 
     config.optimization = {
       splitChunks: {
         chunks: 'all',
         minSize: 20000,
-        maxSize: 250000, // 250KB 단위로 청크를 나눔
+        maxSize: 250000,
         cacheGroups: {
           defaultVendors: {
             test: /[\\/]node_modules[\\/]/,
@@ -160,9 +166,13 @@ module.exports = () => {
         },
       },
     };
-    config.plugins.push(new BundleAnalyzerPlugin()); /* 원할때만 켜기 */
+
+    if (process.env.ANALYZE_BUNDLE === 'true') {
+      config.plugins.push(new BundleAnalyzerPlugin());
+    }
   } else {
     config.mode = 'development';
   }
+
   return config;
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5679,6 +5679,13 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -5690,7 +5697,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -13324,16 +13331,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13436,14 +13434,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15144,7 +15135,7 @@ workbox-window@7.1.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.1.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15157,15 +15148,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## ❗ Issue

- #595 

## ✨ 구현한 기능

기존에는 빌드 모드 (dev/pro) 를 scripts 로 썼습니다.
또한 모든 환경 변수를 env 한 파일에서 관리를 하는 형태였습니다. 
모드 마다 다른 환경 변수를 써야 할때는, 필요한 곳에서 분기 처리를 해주어야 했습니다.

<img width="134" alt="스크린샷 2024-09-12 오전 10 35 22" src="https://github.com/user-attachments/assets/6faec187-9a1a-40a4-a37e-cc2bfdfb77a5">

또한 env 에서 mode 를 바꿔서 api 환경을 설정해줘야 했습니다. 
api 환경을 매번 바꾸기 위해 환경 변수를 직접 건드리는 방법은 위험하고, 번거로워서 다음과 같은 리팩토링을 진행했습니다. 

- 환경 모드 (prod-api / dev-api / msw ) 를 스크립트 명령어로 쉽게 설정할 수 있도록 수정
- 환경 모드에 따라 배포 모드 (production / development) 를 자동으로 설정하도록 수정

### (1) 환경 변수 분리 
환경 변수를 4가지로 분리했습니다. 노션에 해당 파일을 올렸습니다😀
`env` : 공통 환경 변수 파일
`env.msw / env.development / env.production ` : 해당 모드에서만 쓰는 환경 변수 파일 

모드는 `API_ENV` 로 각 파일에 있으며, 각 스크립트 명령어에서 해당 명령어를 전달하는 구조입니다. 

### (3) `package.json` 에  명령어 수정

`yarn build` : production 모드로 빌드하는 명령어입니다.
`yarn prod` : production api 를 사용하고, production 모드로 서버를 킵니다.
`yarn dev` :  development api 를 사용하고, development 모드로 서버를 킵니다.
`yarn msw` : msw 를 사용하고, development 모드로 서버를 킵니다.

이제 env 에서 모드를 바꾸지 말고 스크립트 명령어를 사용해서 서버를 키시면 됩니다!


## 📢 논의하고 싶은 내용



## 🎸 기타

