### PR TITLE
[FE] 메모 커서가 앞으로가는 버그를 수정한다. 

### DIFF
--- a/frontend/src/components/NewChecklist/MemoModal/MemoModal.tsx
+++ b/frontend/src/components/NewChecklist/MemoModal/MemoModal.tsx
@@ -61,7 +61,6 @@ const MemoModal = ({ isModalOpen, modalClose }: Props) => {
         <S.TextareaBox>
           <Textarea
             placeholder="메모를 입력하세요."
-            autoFocus
             height={'large'}
             value={memo}
             onChange={handleInputChange}

--- a/frontend/src/components/_common/Textarea/Textarea.tsx
+++ b/frontend/src/components/_common/Textarea/Textarea.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { ChangeEvent, useCallback } from 'react';
+import { ChangeEvent, useCallback, useEffect, useRef } from 'react';
 
 import { flexCenter } from '@/styles/common';
 
@@ -38,17 +38,29 @@ const Textarea = ({
   hasBorder = false,
   ...rest
 }: Props) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
   const handleChange = useCallback(
     (event: TextareaChangeEvent) => {
       if (!onChange) return;
+
       onChange(event);
     },
     [onChange],
   );
 
+  useEffect(() => {
+    if (textareaRef.current) {
+      const length = textareaRef.current.value.length;
+      textareaRef.current.focus();
+      textareaRef.current.setSelectionRange(length, length);
+    }
+  }, []);
+
   return (
     <S.Box hasBorder={hasBorder}>
       <S.Textarea
+        ref={textareaRef}
         width={widthSize[width]}
         height={heightSize[height]}
         {...rest}


### PR DESCRIPTION
## ❗ Issue

- #590 

## ✨ 구현한 기능

- 메모의 커서가 앞으로 가는 버그를 수정하였습니다. 
- 메모의 textarea 에 useEffect를 사용해서 렌더링 된 이후, setSelectionRange 로 커서의 위치를 직접 조작하였습니다. 

## 📢 논의하고 싶은 내용



## 🎸 기타

