### PR TITLE
[FE] 좋아요 기능 무한정 호출을 막기 위한 디바운스를 추가한다. 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "cross-env NODE_ENV=production API_ENV=production webpack --mode=production",
+    "build:dev": "cross-env NODE_ENV=production API_ENV=development webpack --mode=development",
     "build:analyze": "cross-env NODE_ENV=production API_ENV=production BUNDLE_ANALYZE=on webpack --mode=production",
     "prod": "cross-env NODE_ENV=production API_ENV=production webpack serve --mode=production --open",
     "dev": "cross-env NODE_ENV=development API_ENV=development webpack serve --mode=development --open",

--- a/frontend/src/components/_common/Like/LikeButton.tsx
+++ b/frontend/src/components/_common/Like/LikeButton.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import Like from '@/assets/icons/like/Like';
 import useToggleLikeQuery from '@/hooks/query/useToggleLikeQuery';
 import useDebounce from '@/hooks/useDebounce';
@@ -9,15 +11,23 @@ interface Props {
 }
 
 const LikeButton = ({ isLiked = false, checklistId }: Props) => {
+  const [localIsLiked, setLocalIsLiked] = useState(isLiked);
   const { mutate: toggleLike, variables, isPending } = useToggleLikeQuery();
-  const debouncedIsLiked = useDebounce({ value: isPending ? variables.isLiked : isLiked, delay: 500 });
+
+  const debouncedIsLiked = useDebounce({ value: localIsLiked, delay: 500 });
+
+  useEffect(() => {
+    if (debouncedIsLiked !== isLiked) {
+      toggleLike({ checklistId, isLiked: debouncedIsLiked });
+    }
+  }, [debouncedIsLiked, checklistId, isLiked, toggleLike]);
 
   const handleClickLike = (e: React.MouseEvent<SVGSVGElement>) => {
+    setLocalIsLiked(prev => !prev);
     e.stopPropagation();
-    toggleLike({ checklistId, isLiked: !debouncedIsLiked });
   };
 
-  const fill = isPending ? variables.isLiked : isLiked;
+  const fill = isPending ? variables.isLiked : localIsLiked;
 
   return (
     <Like

--- a/frontend/src/components/_common/Like/LikeButton.tsx
+++ b/frontend/src/components/_common/Like/LikeButton.tsx
@@ -1,5 +1,6 @@
 import Like from '@/assets/icons/like/Like';
 import useToggleLikeQuery from '@/hooks/query/useToggleLikeQuery';
+import useDebounce from '@/hooks/useDebounce';
 import theme from '@/styles/theme';
 
 interface Props {
@@ -9,10 +10,11 @@ interface Props {
 
 const LikeButton = ({ isLiked = false, checklistId }: Props) => {
   const { mutate: toggleLike, variables, isPending } = useToggleLikeQuery();
+  const debouncedIsLiked = useDebounce({ value: isPending ? variables.isLiked : isLiked, delay: 500 });
 
   const handleClickLike = (e: React.MouseEvent<SVGSVGElement>) => {
     e.stopPropagation();
-    toggleLike({ checklistId, isLiked });
+    toggleLike({ checklistId, isLiked: !debouncedIsLiked });
   };
 
   const fill = isPending ? variables.isLiked : isLiked;

--- a/frontend/src/hooks/query/useToggleLikeQuery.ts
+++ b/frontend/src/hooks/query/useToggleLikeQuery.ts
@@ -10,8 +10,8 @@ const useToggleLikeQuery = () => {
 
   return useMutation({
     mutationFn: async ({ checklistId, isLiked }: { checklistId: number; isLiked: boolean }) => {
-      if (isLiked) return deleteLike(checklistId);
-      return postLike(checklistId);
+      if (isLiked) return postLike(checklistId);
+      return deleteLike(checklistId);
     },
     onSuccess: () => {
       invalidateChecklistListQuery();

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+interface Props<T> {
+  value: T;
+  delay?: number;
+}
+
+const useDebounce = <T>({ value, delay = 1000 }: Props<T>) => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -12,7 +12,6 @@ const useDebounce = <T>({ value, delay = 1000 }: Props<T>) => {
     const timer = setTimeout(() => {
       setDebouncedValue(value);
     }, delay);
-
     return () => clearTimeout(timer);
   }, [value, delay]);
 

--- a/frontend/src/mocks/handlers/checklist.ts
+++ b/frontend/src/mocks/handlers/checklist.ts
@@ -39,15 +39,18 @@ export const checklistHandlers = [
   http.get(BASE_URL + ENDPOINT.CHECKLIST_ALL_QUESTION, () => {
     return HttpResponse.json(checklistAllQuestions, { status: 200 });
   }),
+
   http.post(BASE_URL + ENDPOINT.LIKE(1), () => {
     const id = 1;
     addLike(id);
     return HttpResponse.json(null, { status: 200 });
   }),
+
   http.delete(BASE_URL + ENDPOINT.LIKE(1), () => {
     removeLike(1);
     return HttpResponse.json(null, { status: 200 });
   }),
+
   http.get(BASE_URL + ENDPOINT.LIKE(1), () => {
     return HttpResponse.json(checklist.get(1), { status: 200 });
   }),


### PR DESCRIPTION
## ❗ Issue

- #609 

## ✨ 구현한 기능

-  디바운스 커스텀 훅을 제작했습니다. 
- 제작한 커스텀 훅과 좋아요 쿼리를 접목하여 1초 동안 동일한 호출을 막았습니다. 1초라는 숫자는 기본으로 저장해놔서 이후 변경되어도 무관할거 같습니다. 


## 📢 논의하고 싶은 내용



## 🎸 기타

