### PR TITLE
[FE] 커스텀 질문 페이지에서 0개 선택 후 저장시 생기는 버그를 수정한다. 

### DIFF
--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -1,4 +1,4 @@
-import { MAX_SELECT_CATEGORY_COUNT } from '@/constants/system';
+import { MAX_SELECT_CATEGORY_COUNT, MIN_SELECT_CUSTOM_COUNT } from '@/constants/system';
 import { TipType } from '@/hooks/useHandleTipBox';
 
 export const TIP_MESSAGE: Record<TipType, string> = {
@@ -12,10 +12,11 @@ export const MODAL_MESSAGE: Record<ModalMessageType, string> = {
   SUMMARY: '방에 대한 한 줄 평을 적어주세요.',
 };
 
-type ToastType = 'ADD' | 'EDIT' | 'MAX_SELECT';
+type ToastType = 'ADD' | 'EDIT' | 'MIN_CUSTOM_SELECT' | 'MAX_SELECT';
 
 export const TOAST_MESSAGE: Record<ToastType, string> = {
   ADD: '체크리스트가 저장됐어요!',
   EDIT: '체크리스트가 수정됐어요!',
+  MIN_CUSTOM_SELECT: `질문은 최소 ${MIN_SELECT_CUSTOM_COUNT}개 이상 선택해야해요!`,
   MAX_SELECT: `카테고리는 최대 ${MAX_SELECT_CATEGORY_COUNT}개까지만 선택할 수 있어요.`,
 };

--- a/frontend/src/constants/system.ts
+++ b/frontend/src/constants/system.ts
@@ -6,6 +6,8 @@ export const MAX_CHECKLISTS_DISPLAY_COUNT = 3;
 
 export const MAX_SELECT_CATEGORY_COUNT = 3;
 
+export const MIN_SELECT_CUSTOM_COUNT = 1;
+
 export const DEFAULT_TOAST_DURATION = 2;
 
 export const DEFAULT_CHECKLIST_TAB_PAGE = -1;

--- a/frontend/src/hooks/query/usePutCustomChecklist.ts
+++ b/frontend/src/hooks/query/usePutCustomChecklist.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { putCustomChecklist } from '@/apis/checklist';
+
+const usePutCustomChecklist = () => {
+  return useMutation({
+    mutationFn: (questionIds: number[]) => putCustomChecklist({ questionIds }),
+  });
+};
+
+export default usePutCustomChecklist;

--- a/frontend/src/mocks/handlers/checklist.ts
+++ b/frontend/src/mocks/handlers/checklist.ts
@@ -54,6 +54,10 @@ export const checklistHandlers = [
   http.get(BASE_URL + ENDPOINT.LIKE(1), () => {
     return HttpResponse.json(checklist.get(1), { status: 200 });
   }),
+
+  http.put(BASE_URL + ENDPOINT.CHECKLIST_CUSTOM, () => {
+    return HttpResponse.json({ status: 200 });
+  }),
 ];
 
 const checklist = new Map();

--- a/frontend/src/pages/ChecklistCustomPage.tsx
+++ b/frontend/src/pages/ChecklistCustomPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { getChecklistAllQuestions, putCustomChecklist } from '@/apis/checklist';
+import { getChecklistAllQuestions } from '@/apis/checklist';
 import Button from '@/components/_common/Button/Button';
 import Header from '@/components/_common/Header/Header';
 import Layout from '@/components/_common/layout/Layout';
@@ -11,32 +11,28 @@ import { ChecklistCustomTabs } from '@/components/ChecklistCustom/CustomTabs';
 import QuestionListTemplate from '@/components/ChecklistCustom/QuestionListTemplate/QuestionListTemplate';
 import { TOAST_MESSAGE } from '@/constants/message';
 import { ROUTE_PATH } from '@/constants/routePath';
+import usePutCustomChecklist from '@/hooks/query/usePutCustomChecklist';
 import useHandleTipBox from '@/hooks/useHandleTipBox';
 import useToast from '@/hooks/useToast';
 import useChecklistCustomStore from '@/store/useChecklistCustomStore';
 import theme from '@/styles/theme';
 
 const ChecklistCustomPage = () => {
-  const { showToast } = useToast();
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
+  const { mutate: putCustomChecklist } = usePutCustomChecklist();
   const { setValidCategory, setChecklistAllQuestionList, selectedQuestions } = useChecklistCustomStore();
 
   const { resetShowTipBox } = useHandleTipBox('CUSTOM_QUESTION');
 
   const handleSubmitChecklist = () => {
-    const fetchNewChecklist = async () => {
-      await putCustomChecklist({ questionIds: selectedQuestions });
-    };
-
-    try {
-      fetchNewChecklist().then(() => {
+    putCustomChecklist(selectedQuestions, {
+      onSuccess: () => {
         showToast(TOAST_MESSAGE.ADD);
         navigate(ROUTE_PATH.checklistList);
-      });
-    } catch (error) {
-      console.error(error);
-    }
+      },
+    });
   };
 
   useEffect(() => {
@@ -60,9 +56,9 @@ const ChecklistCustomPage = () => {
         right={<Button label={'저장'} size="small" color="dark" onClick={handleSubmitChecklist} />}
       />
       <TabProvider defaultTab={1}>
-        {/*체크리스트 작성의 탭*/}
+        {/* 질문 카테고리 탭 */}
         <ChecklistCustomTabs />
-        {/*체크리스트 콘텐츠 섹션*/}
+        {/* 질문 콘텐츠 섹션*/}
         <Layout bgColor={theme.palette.background} withHeader withTab>
           <TipBox tipType={'CUSTOM_QUESTION'} />
           <QuestionListTemplate />

--- a/frontend/src/pages/ChecklistCustomPage.tsx
+++ b/frontend/src/pages/ChecklistCustomPage.tsx
@@ -22,11 +22,16 @@ const ChecklistCustomPage = () => {
   const { showToast } = useToast();
 
   const { mutate: putCustomChecklist } = usePutCustomChecklist();
-  const { setValidCategory, setChecklistAllQuestionList, selectedQuestions } = useChecklistCustomStore();
+  const { selectedQuestions, setValidCategory, setChecklistAllQuestionList } = useChecklistCustomStore();
 
   const { resetShowTipBox } = useHandleTipBox('CUSTOM_QUESTION');
 
   const handleSubmitChecklist = () => {
+    if (!selectedQuestions.length) {
+      showToast(TOAST_MESSAGE.MIN_CUSTOM_SELECT);
+      return;
+    }
+
     putCustomChecklist(selectedQuestions, {
       onSuccess: () => {
         showToast(TOAST_MESSAGE.ADD);


### PR DESCRIPTION
## ❗ Issue

- #636 

## ✨ 구현한 기능

### 커스텀 질문 선택 시 0개 선택 이후 아무런 에러가 안뜨는 버그 수정
기존에는 질문을 아무것도 선택하지 않고 저장을 눌렀을 때 토스트 메세지나 알럿 메세지가 아무것도 나타나지 않아서 사용자에게 화면이 작동하지 않게 보이는 버그가 있었습니다. 

저장 버튼 호출 시 선택된 질문이 0개일시 저장 호출을 막고 에러 토스트를 띄우도록 변경했습니다. 

### 업데이트 호출 쿼리 훅 제작 

기존에는 탄스 쿼리를 사용하지 않고 내부에서 호출하는 형식으로 동작하고 있었습니다. 하지만 현재 상위에서 쿼리문에서 에러가 날때 에러 토스트를 띄우고 있어서 400 에러 메세지를 받아도 아무런 메세지를 받지 못했습니다. 

0개 선택 이외에도 네트워크 오류 등으로 인한 에러 메세지를 띄우기 위해 쿼리문으로 리팩토링 진행했습니다. 

## 📢 논의하고 싶은 내용



## 🎸 기타

