### PR TITLE
[FE] 편집페이지의 기능이 모두 정상 동작하게 만든다

### DIFF
--- a/frontend/src/components/ChecklistDetail/CategoryAccordion.tsx
+++ b/frontend/src/components/ChecklistDetail/CategoryAccordion.tsx
@@ -1,9 +1,9 @@
 import Divider from '@/components/_common/Divider/Divider';
 import ChecklistAnswer from '@/components/ChecklistDetail/CheckListAnswer';
-import { ChecklistCategoryQnA } from '@/types/checklist';
+import { ChecklistCategoryWithAnswer } from '@/types/checklist';
 
 interface Props {
-  category: ChecklistCategoryQnA;
+  category: ChecklistCategoryWithAnswer;
 }
 
 const CategoryAccordion = ({ category }: Props) => {

--- a/frontend/src/components/ChecklistDetail/CheckListAnswer.tsx
+++ b/frontend/src/components/ChecklistDetail/CheckListAnswer.tsx
@@ -2,10 +2,10 @@ import styled from '@emotion/styled';
 
 import AnswerIcon from '@/components/Answer/AnswerIcon';
 import { flexColumn, flexSpaceBetween } from '@/styles/common';
-import { OneQuestionWithAnswer } from '@/types/checklist';
+import { ChecklistQuestionWithAnswer } from '@/types/checklist';
 
 interface Props {
-  QuestionAndAnswer: OneQuestionWithAnswer;
+  QuestionAndAnswer: ChecklistQuestionWithAnswer;
 }
 
 const ChecklistAnswer = ({ QuestionAndAnswer }: Props) => {

--- a/frontend/src/components/ChecklistDetail/ChecklistAnswerSection.tsx
+++ b/frontend/src/components/ChecklistDetail/ChecklistAnswerSection.tsx
@@ -1,10 +1,10 @@
 import Accordion from '@/components/_common/Accordion/Accordion';
 import CategoryAccordion from '@/components/ChecklistDetail/CategoryAccordion';
 import { CATEGORY_COUNT } from '@/constants/category';
-import { ChecklistCategoryQnA } from '@/types/checklist';
+import { ChecklistCategoryWithAnswer } from '@/types/checklist';
 
 interface Props {
-  categories: ChecklistCategoryQnA[];
+  categories: ChecklistCategoryWithAnswer[];
 }
 
 const ChecklistAnswerSection = ({ categories }: Props) => {

--- a/frontend/src/components/NewChecklist/NewChecklistTemplate.tsx
+++ b/frontend/src/components/NewChecklist/NewChecklistTemplate.tsx
@@ -9,7 +9,7 @@ import theme from '@/styles/theme';
 
 const NewChecklistTemplate = () => {
   const { currentTabId } = useTabContext();
-  const { getCategoryQnA } = useChecklistStore();
+  const { getCategory: getCategoryQnA } = useChecklistStore();
 
   const questions = getCategoryQnA(currentTabId);
 

--- a/frontend/src/components/NewChecklist/NewChecklistTemplate.tsx
+++ b/frontend/src/components/NewChecklist/NewChecklistTemplate.tsx
@@ -9,9 +9,9 @@ import theme from '@/styles/theme';
 
 const NewChecklistTemplate = () => {
   const { currentTabId } = useTabContext();
-  const { getCategory: getCategoryQnA } = useChecklistStore();
+  const checklistActions = useChecklistStore(store => store.actions);
 
-  const questions = getCategoryQnA(currentTabId);
+  const questions = checklistActions.getCategory(currentTabId);
 
   return (
     <Layout bgColor={theme.palette.background} withHeader withTab>

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/OccupancyMonth.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/OccupancyMonth.tsx
@@ -15,7 +15,7 @@ const OccupancyMonth = () => {
 
   return (
     <FlexBox.Vertical gap="1.5rem">
-      <FormField.Label label="입주 가능 일자" />
+      <FormField.Label label="입주 가능일" />
       <FormStyled.FieldBox>
         <FormField.Input width="medium" onChange={actions.onChange} name="occupancyMonth" value={occupancyMonth} />
         <FormStyled.FlexLabel label="월  " />

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/OccupancyMonth.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/OccupancyMonth.tsx
@@ -15,7 +15,7 @@ const OccupancyMonth = () => {
 
   return (
     <FlexBox.Vertical gap="1.5rem">
-      <FormField.Label label="입주 가능 기간" />
+      <FormField.Label label="입주 가능 일자" />
       <FormStyled.FieldBox>
         <FormField.Input width="medium" onChange={actions.onChange} name="occupancyMonth" value={occupancyMonth} />
         <FormStyled.FlexLabel label="월  " />

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/OccupancyMonth.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/OccupancyMonth.tsx
@@ -4,6 +4,7 @@ import Dropdown from '@/components/_common/Dropdown/Dropdown';
 import FlexBox from '@/components/_common/FlexBox/FlexBox';
 import FormField from '@/components/_common/FormField/FormField';
 import FormStyled from '@/components/NewChecklist/NewRoomInfoForm/styled';
+import { roomOccupancyPeriods } from '@/constants/roomInfo';
 import checklistRoomInfoStore from '@/store/checklistRoomInfoStore';
 
 const OccupancyMonth = () => {
@@ -21,7 +22,7 @@ const OccupancyMonth = () => {
         <FormStyled.FlexLabel label="월  " />
         <Dropdown
           initialValue={occupancyPeriod}
-          options={['초', '중순', '말'].map(value => ({ value }))}
+          options={roomOccupancyPeriods.map(value => ({ value }))}
           onSelectSetter={(level: string) => {
             actions.set('occupancyPeriod', level);
           }}

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomFloor.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomFloor.tsx
@@ -13,6 +13,12 @@ const RoomFloor = () => {
   const floorLevel = useStore(checklistRoomInfoStore, state => state.rawValue.floorLevel);
   const errorMessageFloor = useStore(checklistRoomInfoStore, state => state.errorMessage.floor);
 
+  const handleClickDropdown = (level: string) => {
+    actions.set('floorLevel', level);
+    if (level === '반지하/지하') {
+      actions.set('floor', '');
+    }
+  };
   return (
     <FormField>
       <FormField.Label label="층수" />
@@ -20,9 +26,7 @@ const RoomFloor = () => {
         <Dropdown
           initialValue={floorLevel}
           options={roomFloorLevels.map(value => ({ value }))}
-          onSelectSetter={(level: string) => {
-            actions.set('floorLevel', level);
-          }}
+          onSelectSetter={handleClickDropdown}
         />
         <Input
           width="medium"

--- a/frontend/src/constants/roomInfo.ts
+++ b/frontend/src/constants/roomInfo.ts
@@ -1,6 +1,7 @@
 export const roomStructures = ['오픈형 원룸', '분리형 원룸', '투룸', '쓰리룸 이상'] as const;
 
 export const roomFloorLevels = ['지상', '반지하/지하', '옥탑'] as const;
+export const roomOccupancyPeriods = ['초', '중순', '말'] as const;
 
 export const IncludedMaintenancesData = [
   { id: 1, displayName: '수도' },

--- a/frontend/src/hooks/query/useGetChecklistQuestionQuery.ts
+++ b/frontend/src/hooks/query/useGetChecklistQuestionQuery.ts
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getChecklistQuestions } from '@/apis/checklist';
 import { QUERY_KEYS } from '@/constants/queryKeys';
-import { ChecklistCategoryQuestions } from '@/types/checklist';
+import { ChecklistCategory } from '@/types/checklist';
 
 const useGetChecklistQuestionQuery = () => {
-  return useQuery<ChecklistCategoryQuestions[]>({
+  return useQuery<ChecklistCategory[]>({
     queryKey: [QUERY_KEYS.CHECKLIST_QUESTIONS],
     queryFn: getChecklistQuestions,
   });

--- a/frontend/src/hooks/useChecklistAnswer.test.ts
+++ b/frontend/src/hooks/useChecklistAnswer.test.ts
@@ -8,8 +8,8 @@ import useChecklistStore from '@/store/useChecklistStore';
 describe('useChecklistAnswer 테스트', () => {
   beforeEach(() => {
     const { result } = renderHook(() => useChecklistStore());
-    act(() => result.current.reset());
-    act(() => result.current.initAnswerSheetIfEmpty(checklistQuestions.categories));
+    act(() => result.current.actions.reset());
+    act(() => result.current.actions.initAnswerSheetIfEmpty(checklistQuestions.categories));
   });
 
   it('Answer가 없을 때, null을 응답한다.', () => {

--- a/frontend/src/hooks/useChecklistAnswer.ts
+++ b/frontend/src/hooks/useChecklistAnswer.ts
@@ -7,7 +7,7 @@ interface UpdateAnswerProps extends CategoryAndQuestion {
 }
 
 const useChecklistAnswer = () => {
-  const { checklistCategoryQnA, setAnswers, getCategoryQnA } = useChecklistStore();
+  const { checklistCategoryQnA, set: setAnswers, getCategoryQnA } = useChecklistStore();
 
   const updateAndToggleAnswer = ({ categoryId, questionId, newAnswer }: UpdateAnswerProps) => {
     const targetCategory = getCategoryQnA(categoryId);

--- a/frontend/src/hooks/useChecklistAnswer.ts
+++ b/frontend/src/hooks/useChecklistAnswer.ts
@@ -7,7 +7,7 @@ interface UpdateAnswerProps extends CategoryAndQuestion {
 }
 
 const useChecklistAnswer = () => {
-  const { checklistCategoryQnA, set: setAnswers, getCategoryQnA } = useChecklistStore();
+  const { checklistCategoryQnA, set: setAnswers, getCategory: getCategoryQnA } = useChecklistStore();
 
   const updateAndToggleAnswer = ({ categoryId, questionId, newAnswer }: UpdateAnswerProps) => {
     const targetCategory = getCategoryQnA(categoryId);

--- a/frontend/src/hooks/useChecklistAnswer.ts
+++ b/frontend/src/hooks/useChecklistAnswer.ts
@@ -7,10 +7,11 @@ interface UpdateAnswerProps extends CategoryAndQuestion {
 }
 
 const useChecklistAnswer = () => {
-  const { checklistCategoryQnA, set: setAnswers, getCategory: getCategoryQnA } = useChecklistStore();
+  const checklistActions = useChecklistStore(store => store.actions);
+  const checklistCategoryQnA = useChecklistStore(store => store.checklistCategoryQnA);
 
   const updateAndToggleAnswer = ({ categoryId, questionId, newAnswer }: UpdateAnswerProps) => {
-    const targetCategory = getCategoryQnA(categoryId);
+    const targetCategory = checklistActions.getCategory(categoryId);
 
     if (targetCategory) {
       const updatedCategory = {
@@ -27,7 +28,7 @@ const useChecklistAnswer = () => {
         category.categoryId === categoryId ? updatedCategory : category,
       );
 
-      setAnswers(newCategories);
+      checklistActions.set(newCategories);
     }
   };
 

--- a/frontend/src/hooks/useInitialChecklist.ts
+++ b/frontend/src/hooks/useInitialChecklist.ts
@@ -5,7 +5,7 @@ import useGetChecklistQuestionQuery from '@/hooks/query/useGetChecklistQuestionQ
 import useChecklistStore from '@/store/useChecklistStore';
 
 const useInitialChecklist = () => {
-  const initAnswerSheetIfEmpty = useChecklistStore(state => state.initAnswerSheetIfEmpty);
+  const initAnswerSheetIfEmpty = useChecklistStore(state => state.actions.initAnswerSheetIfEmpty);
 
   useDefaultRoomName();
 

--- a/frontend/src/hooks/useMutateChecklist.ts
+++ b/frontend/src/hooks/useMutateChecklist.ts
@@ -7,7 +7,7 @@ import useToast from '@/hooks/useToast';
 import checklistRoomInfoStore from '@/store/checklistRoomInfoStore';
 import useChecklistStore from '@/store/useChecklistStore';
 import useSelectedOptionStore from '@/store/useSelectedOptionStore';
-import { ChecklistCategoryQnA, MutateType } from '@/types/checklist';
+import { ChecklistCategoryWithAnswer, MutateType } from '@/types/checklist';
 
 const useMutateChecklist = (mutateType: MutateType, checklistId?: number) => {
   const { showToast } = useToast({ type: 'positive' });
@@ -66,7 +66,7 @@ const useMutateChecklist = (mutateType: MutateType, checklistId?: number) => {
 export default useMutateChecklist;
 
 // 현재 상태를 백엔드에 보내는 답안 포맷으로 바꾸는 함수
-const transformQuestions = (checklist: ChecklistCategoryQnA[]) => {
+const transformQuestions = (checklist: ChecklistCategoryWithAnswer[]) => {
   return checklist.flatMap(category =>
     category.questions.map(question => ({
       questionId: question.questionId,

--- a/frontend/src/hooks/useNewChecklistTabs.ts
+++ b/frontend/src/hooks/useNewChecklistTabs.ts
@@ -5,16 +5,18 @@ import { findCategoryClassNameByName } from '@/constants/category';
 import useChecklistStore from '@/store/useChecklistStore';
 
 const useNewChecklistTabs = () => {
-  const { getCategory: getCategoryQnA, categories, checklistCategoryQnA } = useChecklistStore();
+  const categories = useChecklistStore(state => state.categories);
+  const checklistCategoryQnA = useChecklistStore(state => state.checklistCategoryQnA);
+  const actions = useChecklistStore(state => state.actions);
 
   const [tabs, setTabs] = useState<TabWithCompletion[]>([]);
 
   const isCategoryQuestionAllCompleted = useCallback(
     (targetId: number) => {
-      const targetCategory = getCategoryQnA(targetId);
+      const targetCategory = actions.getCategory(targetId);
       return targetCategory?.questions.every(question => question.answer !== 'NONE');
     },
-    [getCategoryQnA],
+    [actions.getCategory],
   );
 
   useEffect(() => {

--- a/frontend/src/hooks/useNewChecklistTabs.ts
+++ b/frontend/src/hooks/useNewChecklistTabs.ts
@@ -5,7 +5,7 @@ import { findCategoryClassNameByName } from '@/constants/category';
 import useChecklistStore from '@/store/useChecklistStore';
 
 const useNewChecklistTabs = () => {
-  const { getCategoryQnA, validCategory, checklistCategoryQnA } = useChecklistStore();
+  const { getCategoryQnA, categories: validCategory, checklistCategoryQnA } = useChecklistStore();
 
   const [tabs, setTabs] = useState<TabWithCompletion[]>([]);
 

--- a/frontend/src/hooks/useNewChecklistTabs.ts
+++ b/frontend/src/hooks/useNewChecklistTabs.ts
@@ -5,7 +5,7 @@ import { findCategoryClassNameByName } from '@/constants/category';
 import useChecklistStore from '@/store/useChecklistStore';
 
 const useNewChecklistTabs = () => {
-  const { getCategoryQnA, categories: validCategory, checklistCategoryQnA } = useChecklistStore();
+  const { getCategory: getCategoryQnA, categories, checklistCategoryQnA } = useChecklistStore();
 
   const [tabs, setTabs] = useState<TabWithCompletion[]>([]);
 
@@ -18,7 +18,7 @@ const useNewChecklistTabs = () => {
   );
 
   useEffect(() => {
-    const newChecklistTabsWithCompletion = validCategory.map(category => ({
+    const newChecklistTabsWithCompletion = categories.map(category => ({
       id: category.categoryId,
       name: category.categoryName,
       className: findCategoryClassNameByName(category.categoryName),
@@ -36,7 +36,7 @@ const useNewChecklistTabs = () => {
     if (newTabsString !== prevTabsString) {
       setTabs(tabsWithBasicInfoAndOptions);
     }
-  }, [validCategory, checklistCategoryQnA, isCategoryQuestionAllCompleted]);
+  }, [categories, checklistCategoryQnA, isCategoryQuestionAllCompleted]);
 
   return { tabs };
 };

--- a/frontend/src/mocks/fixtures/checklistDetail.ts
+++ b/frontend/src/mocks/fixtures/checklistDetail.ts
@@ -31,7 +31,7 @@ export const checklistDetail: ChecklistInfo = {
   categories: [
     {
       categoryId: 1,
-      categoryName: '주거지',
+      categoryName: '방 컨디션',
       questions: [
         {
           questionId: 1,
@@ -51,7 +51,7 @@ export const checklistDetail: ChecklistInfo = {
     },
     {
       categoryId: 2,
-      categoryName: '시설',
+      categoryName: '외부',
       questions: [
         {
           questionId: 3,

--- a/frontend/src/mocks/fixtures/checklistQuestions.ts
+++ b/frontend/src/mocks/fixtures/checklistQuestions.ts
@@ -1,6 +1,6 @@
-import { ChecklistCategoryQuestions } from '@/types/checklist';
+import { ChecklistCategory } from '@/types/checklist';
 
-export const checklistQuestions: { categories: ChecklistCategoryQuestions[] } = {
+export const checklistQuestions: { categories: ChecklistCategory[] } = {
   categories: [
     {
       categoryId: 1,

--- a/frontend/src/mocks/fixtures/checklistQuestions.ts
+++ b/frontend/src/mocks/fixtures/checklistQuestions.ts
@@ -1,4 +1,6 @@
-export const checklistQuestions = {
+import { ChecklistCategoryQuestions } from '@/types/checklist';
+
+export const checklistQuestions: { categories: ChecklistCategoryQuestions[] } = {
   categories: [
     {
       categoryId: 1,

--- a/frontend/src/pages/ChecklistDetailPage.tsx
+++ b/frontend/src/pages/ChecklistDetailPage.tsx
@@ -46,10 +46,14 @@ const ChecklistDetailPage = () => {
     navigate(ROUTE_PATH.checklistEditOne(Number(checklistId)));
   };
 
+  const handleClickBackward = () => {
+    navigate(ROUTE_PATH.checklistList);
+  };
+
   return (
     <>
       <Header
-        left={<Header.Backward />}
+        left={<Header.Backward onClick={handleClickBackward} />}
         right={
           <FlexBox.Horizontal gap="1.5rem">
             <Header.TextButton onClick={handleEditButton}>편집</Header.TextButton>

--- a/frontend/src/pages/EditChecklistPage.tsx
+++ b/frontend/src/pages/EditChecklistPage.tsx
@@ -27,6 +27,7 @@ const EditChecklistPage = () => {
   const navigate = useNavigate();
   const { checklistId } = useParams() as RouteParams;
   const { tabs } = useNewChecklistTabs();
+  const { set } = useChecklistStore();
 
   const { data: checklist, isSuccess } = useGetChecklistDetailQuery(checklistId);
   const roomInfoActions = useStore(checklistRoomInfoStore, state => state.actions);
@@ -57,7 +58,9 @@ const EditChecklistPage = () => {
         value: checklist.room,
       });
       selectedOptionActions.set(checklist.options.map(option => option.optionId));
+      set(checklist.categories);
     };
+
     setChecklistDataToStore();
   }, [checklistId]);
 

--- a/frontend/src/pages/EditChecklistPage.tsx
+++ b/frontend/src/pages/EditChecklistPage.tsx
@@ -26,10 +26,10 @@ type RouteParams = {
 const EditChecklistPage = () => {
   const navigate = useNavigate();
   const { checklistId } = useParams() as RouteParams;
+  const { data: checklist, isSuccess } = useGetChecklistDetailQuery(checklistId);
   const { tabs } = useNewChecklistTabs();
   const { set } = useChecklistStore();
 
-  const { data: checklist, isSuccess } = useGetChecklistDetailQuery(checklistId);
   const roomInfoActions = useStore(checklistRoomInfoStore, state => state.actions);
 
   // 한줄평 모달

--- a/frontend/src/pages/EditChecklistPage.tsx
+++ b/frontend/src/pages/EditChecklistPage.tsx
@@ -28,7 +28,7 @@ const EditChecklistPage = () => {
   const { checklistId } = useParams() as RouteParams;
   const { data: checklist, isSuccess } = useGetChecklistDetailQuery(checklistId);
   const { tabs } = useNewChecklistTabs();
-  const { set } = useChecklistStore();
+  const checklistActions = useChecklistStore(state => state.actions);
 
   const roomInfoActions = useStore(checklistRoomInfoStore, state => state.actions);
 
@@ -39,12 +39,11 @@ const EditChecklistPage = () => {
   const { isModalOpen: isMemoModalOpen, openModal: memoModalOpen, closeModal: memoModalClose } = useModal();
 
   // TODO: action 분리 필요
-  const resetChecklist = useChecklistStore(state => state.reset);
   const selectedOptionActions = useSelectedOptionStore(state => state.actions);
 
   const resetAndGoDetailPage = () => {
     roomInfoActions.resetAll();
-    resetChecklist();
+    checklistActions.reset();
     selectedOptionActions.reset();
     navigate(ROUTE_PATH.checklistOne(Number(checklistId)));
   };
@@ -58,7 +57,7 @@ const EditChecklistPage = () => {
         value: checklist.room,
       });
       selectedOptionActions.set(checklist.options.map(option => option.optionId));
-      set(checklist.categories);
+      checklistActions.set(checklist.categories);
     };
 
     setChecklistDataToStore();

--- a/frontend/src/pages/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage.tsx
@@ -25,6 +25,7 @@ const NewChecklistPage = () => {
   useChecklistTemplate(); // 체크리스트 질문 가져오기 및 준비
 
   const { tabs } = useNewChecklistTabs();
+
   const roomInfoActions = useStore(checklistRoomInfoStore, state => state.actions);
   // TODO: action 분리 필요
   const resetChecklist = useChecklistStore(state => state.reset);

--- a/frontend/src/pages/NewChecklistPage.tsx
+++ b/frontend/src/pages/NewChecklistPage.tsx
@@ -28,7 +28,7 @@ const NewChecklistPage = () => {
 
   const roomInfoActions = useStore(checklistRoomInfoStore, state => state.actions);
   // TODO: action 분리 필요
-  const resetChecklist = useChecklistStore(state => state.reset);
+  const checklistActions = useChecklistStore(state => state.actions);
   const selectedOptionActions = useSelectedOptionStore(state => state.actions);
   const { resetShowTipBox } = useHandleTipBox('OPTION');
 
@@ -43,7 +43,7 @@ const NewChecklistPage = () => {
 
   const resetAndGoHome = () => {
     roomInfoActions.resetAll();
-    resetChecklist();
+    checklistActions.reset();
     selectedOptionActions.reset();
     resetShowTipBox(); // 옵션의 팁박스 다시표시
     navigate(ROUTE_PATH.checklistList);

--- a/frontend/src/store/checklistRoomInfoStore.ts
+++ b/frontend/src/store/checklistRoomInfoStore.ts
@@ -2,6 +2,7 @@ import createFormStore, { FormSpec } from '@/store/createFormStore';
 import { RoomInfo } from '@/types/room';
 import { objectMap } from '@/utils/typeFunctions';
 import {
+  inRangeValidator,
   isIntegerValidator,
   isNumericValidator,
   lengthValidator,
@@ -25,7 +26,11 @@ const formSpec: FormSpec<RoomInfo> = {
   floorLevel: { initialValue: '지상', type: 'string', validators: [] },
   structure: { initialValue: '', type: 'string', validators: [] },
   realEstate: { initialValue: '', type: 'string', validators: [] },
-  occupancyMonth: { initialValue: '', type: 'number', validators: [isIntegerValidator, positiveValidator] },
+  occupancyMonth: {
+    initialValue: '',
+    type: 'number',
+    validators: [isIntegerValidator, positiveValidator, inRangeValidator(1, 12)],
+  },
   occupancyPeriod: { initialValue: '초', type: 'string', validators: [] },
   summary: { initialValue: '', type: 'string', validators: [] },
   memo: { initialValue: '', type: 'string', validators: [] },

--- a/frontend/src/store/checklistRoomInfoStore.ts
+++ b/frontend/src/store/checklistRoomInfoStore.ts
@@ -1,3 +1,4 @@
+import { roomFloorLevels, roomOccupancyPeriods } from '@/constants/roomInfo';
 import createFormStore, { FormSpec } from '@/store/createFormStore';
 import { RoomInfo } from '@/types/room';
 import { objectMap } from '@/utils/typeFunctions';
@@ -23,7 +24,7 @@ const formSpec: FormSpec<RoomInfo> = {
   type: { initialValue: '', type: 'string', validators: [] },
   size: { initialValue: '', type: 'number', validators: [isNumericValidator] },
   floor: { initialValue: '', type: 'number', validators: [isIntegerValidator, positiveValidator] },
-  floorLevel: { initialValue: '지상', type: 'string', validators: [] },
+  floorLevel: { initialValue: roomFloorLevels[0], type: 'string', validators: [] },
   structure: { initialValue: '', type: 'string', validators: [] },
   realEstate: { initialValue: '', type: 'string', validators: [] },
   occupancyMonth: {
@@ -31,7 +32,7 @@ const formSpec: FormSpec<RoomInfo> = {
     type: 'number',
     validators: [isIntegerValidator, positiveValidator, inRangeValidator(1, 12)],
   },
-  occupancyPeriod: { initialValue: '초', type: 'string', validators: [] },
+  occupancyPeriod: { initialValue: roomOccupancyPeriods[0], type: 'string', validators: [] },
   summary: { initialValue: '', type: 'string', validators: [] },
   memo: { initialValue: '', type: 'string', validators: [] },
 };

--- a/frontend/src/store/useChecklistCustomStore.ts
+++ b/frontend/src/store/useChecklistCustomStore.ts
@@ -1,16 +1,16 @@
 import { create } from 'zustand';
 
 import { Category, CategoryName } from '@/types/category';
-import { CategoryAndQuestion, ChecklistCategoryQnIsSelected, ChecklistQuestionWithIsSelected } from '@/types/checklist';
+import { CategoryAndQuestion, ChecklistCategoryCustom, ChecklistQuestionWithIsSelected } from '@/types/checklist';
 
 interface ChecklistCustomState {
   selectedQuestions: number[];
-  checklistAllQuestionList: ChecklistCategoryQnIsSelected[];
+  checklistAllQuestionList: ChecklistCategoryCustom[];
   validCategory: Category[];
 
-  setChecklistAllQuestionList: (answers: ChecklistCategoryQnIsSelected[]) => void;
+  setChecklistAllQuestionList: (answers: ChecklistCategoryCustom[]) => void;
   findCategoryQuestion: ({ categoryId, questionId }: CategoryAndQuestion) => ChecklistQuestionWithIsSelected | null;
-  categoryQnA: (categoryId: number) => ChecklistCategoryQnIsSelected;
+  categoryQnA: (categoryId: number) => ChecklistCategoryCustom;
   setValidCategory: () => void;
 }
 
@@ -19,7 +19,7 @@ const useChecklistCustomStore = create<ChecklistCustomState>((set, get) => ({
   checklistAllQuestionList: [],
   validCategory: [],
 
-  setChecklistAllQuestionList: (categoryQuestions: ChecklistCategoryQnIsSelected[]) => {
+  setChecklistAllQuestionList: (categoryQuestions: ChecklistCategoryCustom[]) => {
     const defaultSelectedQuestions = categoryQuestions.flatMap(category =>
       category.questions.filter(question => question.isSelected).map(question => question.questionId),
     );

--- a/frontend/src/store/useChecklistStore.ts
+++ b/frontend/src/store/useChecklistStore.ts
@@ -5,7 +5,6 @@ import { Category, CategoryName } from '@/types/category';
 import { ChecklistCategoryQnA, ChecklistCategoryQuestions } from '@/types/checklist';
 
 interface ChecklistState {
-  basicInfo: Record<string, unknown>;
   checklistCategoryQnA: ChecklistCategoryQnA[];
   validCategory: Category[];
   reset: () => void;
@@ -19,11 +18,9 @@ interface ChecklistState {
 const useChecklistStore = create<ChecklistState>()(
   persist(
     (set, get) => ({
-      basicInfo: {},
       checklistCategoryQnA: [],
       validCategory: [],
 
-      _isEmptyCategoryQnA: () => get().checklistCategoryQnA.length === 0,
       initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => {
         if (!get()._isEmptyCategoryQnA()) return;
 
@@ -40,16 +37,6 @@ const useChecklistStore = create<ChecklistState>()(
         get()._setValidCategory();
       },
 
-      _setValidCategory: () => {
-        const { checklistCategoryQnA } = get();
-        const validCategory = checklistCategoryQnA.map(category => ({
-          categoryId: category.categoryId,
-          categoryName: category.categoryName as CategoryName,
-        }));
-
-        set({ validCategory });
-      },
-
       getCategoryQnA: (categoryId: number) => {
         const { checklistCategoryQnA } = get();
         return checklistCategoryQnA.find(category => category.categoryId === categoryId);
@@ -60,13 +47,23 @@ const useChecklistStore = create<ChecklistState>()(
         get()._setValidCategory();
       },
       reset: () => {
-        set({ basicInfo: {}, checklistCategoryQnA: [], validCategory: [] });
+        set({ checklistCategoryQnA: [], validCategory: [] });
+      },
+
+      _isEmptyCategoryQnA: () => get().checklistCategoryQnA.length === 0,
+      _setValidCategory: () => {
+        const { checklistCategoryQnA } = get();
+        const validCategory = checklistCategoryQnA.map(category => ({
+          categoryId: category.categoryId,
+          categoryName: category.categoryName as CategoryName,
+        }));
+
+        set({ validCategory });
       },
     }),
     {
       name: 'checklist-answer',
       partialize: state => ({
-        basicInfo: state.basicInfo,
         checklistCategoryQnA: state.checklistCategoryQnA,
         validCategory: state.validCategory,
         // actions는 저장하지 않음

--- a/frontend/src/store/useChecklistStore.ts
+++ b/frontend/src/store/useChecklistStore.ts
@@ -1,18 +1,17 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import { Category, CategoryName } from '@/types/category';
+import { Category } from '@/types/category';
 import { ChecklistCategoryQnA, ChecklistCategoryQuestions } from '@/types/checklist';
 
 interface ChecklistState {
   checklistCategoryQnA: ChecklistCategoryQnA[];
   categories: Category[];
   reset: () => void;
-  getCategoryQnA: (categoryId: number) => ChecklistCategoryQnA | undefined;
+  getCategory: (categoryId: number) => ChecklistCategoryQnA | undefined;
   initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => void;
   set: (answers: ChecklistCategoryQnA[]) => void;
   _parseCategory: () => void;
-  _isEmptyCategoryQnA: () => boolean;
 }
 
 const useChecklistStore = create<ChecklistState>()(
@@ -22,7 +21,7 @@ const useChecklistStore = create<ChecklistState>()(
       categories: [],
 
       initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => {
-        if (!get()._isEmptyCategoryQnA()) return;
+        if (get().checklistCategoryQnA.length !== 0) return;
 
         const checklistCategoryQnA: ChecklistCategoryQnA[] = questions.map(category => ({
           categoryId: category.categoryId,
@@ -37,7 +36,7 @@ const useChecklistStore = create<ChecklistState>()(
         get()._parseCategory();
       },
 
-      getCategoryQnA: (categoryId: number) => {
+      getCategory: (categoryId: number) => {
         const { checklistCategoryQnA } = get();
         return checklistCategoryQnA.find(category => category.categoryId === categoryId);
       },
@@ -50,12 +49,11 @@ const useChecklistStore = create<ChecklistState>()(
         set({ checklistCategoryQnA: [], categories: [] });
       },
 
-      _isEmptyCategoryQnA: () => get().checklistCategoryQnA.length === 0,
       _parseCategory: () => {
         const { checklistCategoryQnA } = get();
         const categories = checklistCategoryQnA.map(category => ({
           categoryId: category.categoryId,
-          categoryName: category.categoryName as CategoryName,
+          categoryName: category.categoryName,
         }));
 
         set({ categories });

--- a/frontend/src/store/useChecklistStore.ts
+++ b/frontend/src/store/useChecklistStore.ts
@@ -7,11 +7,13 @@ import { ChecklistCategoryQnA, ChecklistCategoryQuestions } from '@/types/checkl
 interface ChecklistState {
   checklistCategoryQnA: ChecklistCategoryQnA[];
   categories: Category[];
-  reset: () => void;
-  getCategory: (categoryId: number) => ChecklistCategoryQnA | undefined;
-  initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => void;
-  set: (answers: ChecklistCategoryQnA[]) => void;
-  _parseCategory: () => void;
+  actions: {
+    reset: () => void;
+    getCategory: (categoryId: number) => ChecklistCategoryQnA | undefined;
+    initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => void;
+    set: (answers: ChecklistCategoryQnA[]) => void;
+    _parseCategory: () => void;
+  };
 }
 
 const useChecklistStore = create<ChecklistState>()(
@@ -20,43 +22,45 @@ const useChecklistStore = create<ChecklistState>()(
       checklistCategoryQnA: [],
       categories: [],
 
-      initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => {
-        if (get().checklistCategoryQnA.length !== 0) return;
+      actions: {
+        initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => {
+          if (get().checklistCategoryQnA.length !== 0) return;
 
-        const checklistCategoryQnA: ChecklistCategoryQnA[] = questions.map(category => ({
-          categoryId: category.categoryId,
-          categoryName: category.categoryName,
-          questions: category.questions.map(question => ({
-            ...question,
-            answer: 'NONE',
-          })),
-        }));
+          const checklistCategoryQnA: ChecklistCategoryQnA[] = questions.map(category => ({
+            categoryId: category.categoryId,
+            categoryName: category.categoryName,
+            questions: category.questions.map(question => ({
+              ...question,
+              answer: 'NONE',
+            })),
+          }));
 
-        set({ checklistCategoryQnA });
-        get()._parseCategory();
-      },
+          set({ checklistCategoryQnA });
+          get().actions._parseCategory();
+        },
 
-      getCategory: (categoryId: number) => {
-        const { checklistCategoryQnA } = get();
-        return checklistCategoryQnA.find(category => category.categoryId === categoryId);
-      },
+        getCategory: (categoryId: number) => {
+          const { checklistCategoryQnA } = get();
+          return checklistCategoryQnA.find(category => category.categoryId === categoryId);
+        },
 
-      set: (checklistCategoryQnA: ChecklistCategoryQnA[]) => {
-        set({ checklistCategoryQnA });
-        get()._parseCategory();
-      },
-      reset: () => {
-        set({ checklistCategoryQnA: [], categories: [] });
-      },
+        set: (checklistCategoryQnA: ChecklistCategoryQnA[]) => {
+          set({ checklistCategoryQnA });
+          get().actions._parseCategory();
+        },
+        reset: () => {
+          set({ checklistCategoryQnA: [], categories: [] });
+        },
 
-      _parseCategory: () => {
-        const { checklistCategoryQnA } = get();
-        const categories = checklistCategoryQnA.map(category => ({
-          categoryId: category.categoryId,
-          categoryName: category.categoryName,
-        }));
+        _parseCategory: () => {
+          const { checklistCategoryQnA } = get();
+          const categories = checklistCategoryQnA.map(category => ({
+            categoryId: category.categoryId,
+            categoryName: category.categoryName,
+          }));
 
-        set({ categories });
+          set({ categories });
+        },
       },
     }),
     {

--- a/frontend/src/store/useChecklistStore.ts
+++ b/frontend/src/store/useChecklistStore.ts
@@ -6,12 +6,12 @@ import { ChecklistCategoryQnA, ChecklistCategoryQuestions } from '@/types/checkl
 
 interface ChecklistState {
   checklistCategoryQnA: ChecklistCategoryQnA[];
-  validCategory: Category[];
+  categories: Category[];
   reset: () => void;
   getCategoryQnA: (categoryId: number) => ChecklistCategoryQnA | undefined;
   initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => void;
-  setAnswers: (answers: ChecklistCategoryQnA[]) => void;
-  _setValidCategory: () => void;
+  set: (answers: ChecklistCategoryQnA[]) => void;
+  _parseCategory: () => void;
   _isEmptyCategoryQnA: () => boolean;
 }
 
@@ -19,7 +19,7 @@ const useChecklistStore = create<ChecklistState>()(
   persist(
     (set, get) => ({
       checklistCategoryQnA: [],
-      validCategory: [],
+      categories: [],
 
       initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => {
         if (!get()._isEmptyCategoryQnA()) return;
@@ -34,7 +34,7 @@ const useChecklistStore = create<ChecklistState>()(
         }));
 
         set({ checklistCategoryQnA });
-        get()._setValidCategory();
+        get()._parseCategory();
       },
 
       getCategoryQnA: (categoryId: number) => {
@@ -42,30 +42,30 @@ const useChecklistStore = create<ChecklistState>()(
         return checklistCategoryQnA.find(category => category.categoryId === categoryId);
       },
 
-      setAnswers: (answers: ChecklistCategoryQnA[]) => {
-        set({ checklistCategoryQnA: answers });
-        get()._setValidCategory();
+      set: (checklistCategoryQnA: ChecklistCategoryQnA[]) => {
+        set({ checklistCategoryQnA });
+        get()._parseCategory();
       },
       reset: () => {
-        set({ checklistCategoryQnA: [], validCategory: [] });
+        set({ checklistCategoryQnA: [], categories: [] });
       },
 
       _isEmptyCategoryQnA: () => get().checklistCategoryQnA.length === 0,
-      _setValidCategory: () => {
+      _parseCategory: () => {
         const { checklistCategoryQnA } = get();
-        const validCategory = checklistCategoryQnA.map(category => ({
+        const categories = checklistCategoryQnA.map(category => ({
           categoryId: category.categoryId,
           categoryName: category.categoryName as CategoryName,
         }));
 
-        set({ validCategory });
+        set({ categories });
       },
     }),
     {
       name: 'checklist-answer',
       partialize: state => ({
         checklistCategoryQnA: state.checklistCategoryQnA,
-        validCategory: state.validCategory,
+        validCategory: state.categories,
         // actions는 저장하지 않음
       }),
     },

--- a/frontend/src/store/useChecklistStore.ts
+++ b/frontend/src/store/useChecklistStore.ts
@@ -2,16 +2,16 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 import { Category } from '@/types/category';
-import { ChecklistCategoryQnA, ChecklistCategoryQuestions } from '@/types/checklist';
+import { ChecklistCategory, ChecklistCategoryWithAnswer } from '@/types/checklist';
 
 interface ChecklistState {
-  checklistCategoryQnA: ChecklistCategoryQnA[];
+  checklistCategoryQnA: ChecklistCategoryWithAnswer[];
   categories: Category[];
   actions: {
     reset: () => void;
-    getCategory: (categoryId: number) => ChecklistCategoryQnA | undefined;
-    initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => void;
-    set: (answers: ChecklistCategoryQnA[]) => void;
+    getCategory: (categoryId: number) => ChecklistCategoryWithAnswer | undefined;
+    initAnswerSheetIfEmpty: (questions: ChecklistCategory[]) => void;
+    set: (answers: ChecklistCategoryWithAnswer[]) => void;
     _parseCategory: () => void;
   };
 }
@@ -23,10 +23,10 @@ const useChecklistStore = create<ChecklistState>()(
       categories: [],
 
       actions: {
-        initAnswerSheetIfEmpty: (questions: ChecklistCategoryQuestions[]) => {
+        initAnswerSheetIfEmpty: (questions: ChecklistCategory[]) => {
           if (get().checklistCategoryQnA.length !== 0) return;
 
-          const checklistCategoryQnA: ChecklistCategoryQnA[] = questions.map(category => ({
+          const checklistCategoryQnA: ChecklistCategoryWithAnswer[] = questions.map(category => ({
             categoryId: category.categoryId,
             categoryName: category.categoryName,
             questions: category.questions.map(question => ({
@@ -44,7 +44,7 @@ const useChecklistStore = create<ChecklistState>()(
           return checklistCategoryQnA.find(category => category.categoryId === categoryId);
         },
 
-        set: (checklistCategoryQnA: ChecklistCategoryQnA[]) => {
+        set: (checklistCategoryQnA: ChecklistCategoryWithAnswer[]) => {
           set({ checklistCategoryQnA });
           get().actions._parseCategory();
         },

--- a/frontend/src/store/useChecklistStore.ts
+++ b/frontend/src/store/useChecklistStore.ts
@@ -40,8 +40,7 @@ const useChecklistStore = create<ChecklistState>()(
         },
 
         getCategory: (categoryId: number) => {
-          const { checklistCategoryQnA } = get();
-          return checklistCategoryQnA.find(category => category.categoryId === categoryId);
+          return get().checklistCategoryQnA.find(category => category.categoryId === categoryId);
         },
 
         set: (checklistCategoryQnA: ChecklistCategoryWithAnswer[]) => {
@@ -53,8 +52,7 @@ const useChecklistStore = create<ChecklistState>()(
         },
 
         _parseCategory: () => {
-          const { checklistCategoryQnA } = get();
-          const categories = checklistCategoryQnA.map(category => ({
+          const categories = get().checklistCategoryQnA.map(category => ({
             categoryId: category.categoryId,
             categoryName: category.categoryName,
           }));

--- a/frontend/src/store/useChecklistStore.ts
+++ b/frontend/src/store/useChecklistStore.ts
@@ -61,9 +61,9 @@ const useChecklistStore = create<ChecklistState>()(
     }),
     {
       name: 'checklist-answer',
-      partialize: state => ({
-        checklistCategoryQnA: state.checklistCategoryQnA,
-        validCategory: state.categories,
+      partialize: ({ checklistCategoryQnA, categories }) => ({
+        checklistCategoryQnA,
+        categories,
         // actions는 저장하지 않음
       }),
     },

--- a/frontend/src/types/checklist.ts
+++ b/frontend/src/types/checklist.ts
@@ -1,5 +1,5 @@
 import { AnswerType } from '@/types/answer';
-import { CategoryName } from '@/types/category';
+import { Category, CategoryName } from '@/types/category';
 // import { CategoryScore } from '@/types/category';
 import { Option } from '@/types/option';
 import { RoomInfo } from '@/types/room';
@@ -22,7 +22,7 @@ export interface ChecklistQuestion {
 }
 
 // 기본 체크리스트
-export interface ChecklistCategoryQuestions extends ChecklistCategoryBase {
+export interface ChecklistCategoryQuestions extends Category {
   questions: ChecklistQuestion[];
 }
 

--- a/frontend/src/types/checklist.ts
+++ b/frontend/src/types/checklist.ts
@@ -1,4 +1,5 @@
 import { AnswerType } from '@/types/answer';
+import { CategoryName } from '@/types/category';
 // import { CategoryScore } from '@/types/category';
 import { Option } from '@/types/option';
 import { RoomInfo } from '@/types/room';
@@ -10,7 +11,7 @@ export interface CategoryAndQuestion {
 
 interface ChecklistCategoryBase {
   categoryId: number;
-  categoryName: string;
+  categoryName: CategoryName;
 }
 
 export interface ChecklistQuestion {
@@ -27,11 +28,11 @@ export interface ChecklistCategoryQuestions extends ChecklistCategoryBase {
 
 // 체크리스트 작성: 모든 질문 + 답변
 export interface ChecklistCategoryQnA extends ChecklistCategoryBase {
-  questions: OneQuestionWithAnswer[];
+  questions: ChecklistQuestionWithAnswer[];
 }
 
 // 하나의 질문 + 답변 컴포넌트
-export interface OneQuestionWithAnswer extends ChecklistQuestion {
+export interface ChecklistQuestionWithAnswer extends ChecklistQuestion {
   answer: AnswerType;
 }
 

--- a/frontend/src/types/checklist.ts
+++ b/frontend/src/types/checklist.ts
@@ -1,5 +1,5 @@
 import { AnswerType } from '@/types/answer';
-import { Category, CategoryName } from '@/types/category';
+import { Category } from '@/types/category';
 // import { CategoryScore } from '@/types/category';
 import { Option } from '@/types/option';
 import { RoomInfo } from '@/types/room';
@@ -7,11 +7,6 @@ import { RoomInfo } from '@/types/room';
 export interface CategoryAndQuestion {
   categoryId: number;
   questionId: number;
-}
-
-interface ChecklistCategoryBase {
-  categoryId: number;
-  categoryName: CategoryName;
 }
 
 export interface ChecklistQuestion {
@@ -27,7 +22,7 @@ export interface ChecklistCategoryQuestions extends Category {
 }
 
 // 체크리스트 작성: 모든 질문 + 답변
-export interface ChecklistCategoryQnA extends ChecklistCategoryBase {
+export interface ChecklistCategoryQnA extends Category {
   questions: ChecklistQuestionWithAnswer[];
 }
 
@@ -37,7 +32,7 @@ export interface ChecklistQuestionWithAnswer extends ChecklistQuestion {
 }
 
 // 체크리스트 커스텀
-export interface ChecklistCategoryQnIsSelected extends ChecklistCategoryBase {
+export interface ChecklistCategoryQnIsSelected extends Category {
   questions: ChecklistQuestionWithIsSelected[];
 }
 

--- a/frontend/src/types/checklist.ts
+++ b/frontend/src/types/checklist.ts
@@ -1,6 +1,5 @@
 import { AnswerType } from '@/types/answer';
 import { Category } from '@/types/category';
-// import { CategoryScore } from '@/types/category';
 import { Option } from '@/types/option';
 import { RoomInfo } from '@/types/room';
 
@@ -17,12 +16,12 @@ export interface ChecklistQuestion {
 }
 
 // 기본 체크리스트
-export interface ChecklistCategoryQuestions extends Category {
+export interface ChecklistCategory extends Category {
   questions: ChecklistQuestion[];
 }
 
 // 체크리스트 작성: 모든 질문 + 답변
-export interface ChecklistCategoryQnA extends Category {
+export interface ChecklistCategoryWithAnswer extends Category {
   questions: ChecklistQuestionWithAnswer[];
 }
 
@@ -32,7 +31,7 @@ export interface ChecklistQuestionWithAnswer extends ChecklistQuestion {
 }
 
 // 체크리스트 커스텀
-export interface ChecklistCategoryQnIsSelected extends Category {
+export interface ChecklistCategoryCustom extends Category {
   questions: ChecklistQuestionWithIsSelected[];
 }
 
@@ -72,7 +71,7 @@ export interface ChecklistInfo {
   isLiked: boolean;
   room: RoomInfo;
   options: Option[];
-  categories: ChecklistCategoryQnA[];
+  categories: ChecklistCategoryWithAnswer[];
 }
 
 export interface ChecklistCustom {

--- a/frontend/src/types/room.ts
+++ b/frontend/src/types/room.ts
@@ -1,5 +1,6 @@
-export type OccupancyPeriod = '초' | '중순' | '말';
+import { roomOccupancyPeriods } from '@/constants/roomInfo';
 
+export type OccupancyPeriod = (typeof roomOccupancyPeriods)[number];
 export type RoomInfo = Partial<{
   roomName: string;
   deposit: number;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -32,7 +32,7 @@ const config = {
   entry: './src/index.tsx',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js',
+    filename: '[name].[chunkhash].js',
     clean: true,
   },
   devServer: {
@@ -50,8 +50,8 @@ const config = {
   ],
   performance: {
     hints: false,
-    maxEntrypointSize: 512000,
-    maxAssetSize: 512000,
+    // maxEntrypointSize: 512000,
+    // maxAssetSize: 512000,
   },
   module: {
     rules: [
@@ -147,27 +147,21 @@ module.exports = () => {
     config.devtool = 'source-map';
 
     config.optimization = {
+      runtimeChunk: true,
       splitChunks: {
         chunks: 'all',
-        minSize: 20000,
-        maxSize: 250000,
         cacheGroups: {
-          defaultVendors: {
+          vendor: {
             test: /[\\/]node_modules[\\/]/,
-            priority: -10,
-            reuseExistingChunk: true,
-            filename: '[name].js',
-          },
-          default: {
-            minChunks: 2,
-            priority: -20,
-            reuseExistingChunk: true,
+            // reuseExistingChunk: true,
+            filename: '[name].[chunkhash].js',
           },
         },
       },
     };
-    console.log(typeof process.env.BUNDLE_ANALYZE, process.env.BUNDLE_ANALYZE);
+
     if (process.env.BUNDLE_ANALYZE) {
+      console.log('BundleAnalyzer Plugin : ON');
       config.plugins.push(new BundleAnalyzerPlugin());
     }
   } else {


### PR DESCRIPTION
## ❗ Issue

- #615

## ✨ 구현한 기능
 - [!] 과도한 청크 끄기 -> 청크가 나눠질 원인이 없는데 40개의 청크로 분리되고있어 원인파악필요.
- [x] 새 체크리스트Page에서도 층수를 입력해놓고 반지하 선택시 disable만 되던것에서, 내용삭제까지 하게하여 혹시라도 api로 넘어갈 가능성 제거
- [x] 디테일 페이지에서 뒤로가기 클릭시, 뒤로가 아니라 체크리스트목록 페이지로 이동
- [x] 편집 페이지에서 체크리스트 탭이 아예 안보이는 버그 해결 
 - [x] 편집에서 관리비 포함항목 선택안되는 문제
 - [x] 편집에서 로컬스토리지 관리 되고있는지 확인 및 적용
 - [x] 다른 UI 문제는 아직은 발견되지않아 추후발견시 조치
 
useChecklistStore에서
validCategory->category 로 명칭변경 하였습니다.
## 📢 논의하고 싶은 내용
과도한 청크 이슈는 원인파악예정입니다..

## 🎸 기타

