### PR TITLE
[FE] 아티클 대표 이미지 요소를 추가한다.

### DIFF
--- a/frontend/src/components/_common/Header/Header.stories.tsx
+++ b/frontend/src/components/_common/Header/Header.stories.tsx
@@ -42,5 +42,9 @@ export const Triple: Story = {
 };
 
 export const Opacity: Story = {
-  render: () => <Header left={<Header.Backward />} isTransparent />,
+  render: () => (
+    <div style={{ height: '6rem' }}>
+      <Header left={<Header.Backward />} isTransparent />
+    </div>
+  ),
 };

--- a/frontend/src/components/_common/Header/Header.stories.tsx
+++ b/frontend/src/components/_common/Header/Header.stories.tsx
@@ -40,3 +40,7 @@ export const Triple: Story = {
     />
   ),
 };
+
+export const Opacity: Story = {
+  render: () => <Header left={<Header.Backward />} isTransparent />,
+};

--- a/frontend/src/components/_common/Header/Header.tsx
+++ b/frontend/src/components/_common/Header/Header.tsx
@@ -11,19 +11,20 @@ interface Props extends React.HTMLAttributes<HTMLDivElement> {
   left?: ReactNode;
   center?: ReactNode;
   right?: ReactNode;
+  isTransparent?: boolean;
 }
 
-const HeaderWrapper = ({ left, right, center, ...rest }: Props) => {
+const HeaderWrapper = ({ left, right, center, isTransparent = false, ...rest }: Props) => {
   return (
     <>
-      <S.Wrapper {...rest}>
+      <S.Wrapper {...rest} isTransparent={isTransparent}>
         <S.FlexBox>
           <S.Left>{left ? left : <div />}</S.Left>
           <S.Center>{center ? center : <div />}</S.Center>
           <S.Right>{right ? right : <div />}</S.Right>
         </S.FlexBox>
       </S.Wrapper>
-      <S.EmptyBox />
+      {!isTransparent && <S.EmptyBox />}
     </>
   );
 };
@@ -32,7 +33,7 @@ const S = {
   EmptyBox: styled.div`
     height: ${HEADER_SIZE}rem;
   `,
-  Wrapper: styled.header`
+  Wrapper: styled.header<{ isTransparent: boolean }>`
     display: flex;
     position: fixed;
     z-index: ${({ theme }) => theme.zIndex.HEADER};
@@ -41,6 +42,7 @@ const S = {
     padding: 2rem 1.6rem 1.2rem;
 
     background-color: ${({ theme }) => theme.palette.white};
+    opacity: ${({ isTransparent }) => isTransparent && 0.3};
     max-width: 60rem;
     align-items: center;
     box-sizing: border-box;

--- a/frontend/src/components/skeleton/Article/SKArticleDetail.tsx
+++ b/frontend/src/components/skeleton/Article/SKArticleDetail.tsx
@@ -7,7 +7,8 @@ import { flexSpaceBetween, Skeleton } from '@/styles/common';
 const SKArticleDetail = () => {
   return (
     <>
-      <Header left={<Header.Backward />} />
+      <Header left={<Header.Backward />} isTransparent />
+      <S.SkeletonThumbnail />
       <Layout withHeader>
         <S.Row>
           <S.SkeletonKeyword />
@@ -22,6 +23,11 @@ const SKArticleDetail = () => {
 export default SKArticleDetail;
 
 const S = {
+  SkeletonThumbnail: styled.div`
+    width: 100%;
+    height: 250px;
+    ${Skeleton}
+  `,
   Row: styled.div`
     ${flexSpaceBetween}
   `,

--- a/frontend/src/components/skeleton/Article/SkArticleList.tsx
+++ b/frontend/src/components/skeleton/Article/SkArticleList.tsx
@@ -5,7 +5,7 @@ import Layout from '@/components/_common/layout/Layout';
 import { flexColumn, Skeleton } from '@/styles/common';
 import theme from '@/styles/theme';
 
-const SHOW_ARTICLE_COUNT = 3;
+const SHOW_ARTICLE_COUNT = 4;
 
 const SkArticleList = () => {
   return (

--- a/frontend/src/mocks/fixtures/article.ts
+++ b/frontend/src/mocks/fixtures/article.ts
@@ -3,6 +3,7 @@ export const article = {
   keyword: '아파트 임대',
   title: '완벽한 아파트 찾는 팁',
   summary: '첫 임대자를 위한 아파트 찾기 필수 팁',
+  thumbnail: 'https://image.ohou.se/i/bucketplace-v2-development/uploads/cards/snapshots/168217562696278839.jpeg',
   content: `
 **첫 임대자를 위한 아파트 찾기 필수 팁**
 

--- a/frontend/src/pages/ArticleDetailPage.tsx
+++ b/frontend/src/pages/ArticleDetailPage.tsx
@@ -16,21 +16,20 @@ type RouteParams = {
 };
 
 const ArticleDetailPage = () => {
+  const navigate = useNavigate();
   const { articleId } = useParams() as RouteParams;
   const { data: article, isError, isLoading } = useGetArticleQuery(articleId);
-
-  const navigate = useNavigate();
 
   const { color500 } = getSeqColor(article?.articleId ?? 0);
 
   if (isError) navigate(ROUTE_PATH.articleList);
-
   if (isLoading) return <SKArticleDetail />;
 
   return (
     <>
-      <Header left={<Header.Backward />} />
-      <Layout withHeader>
+      <Header left={<Header.Backward />} isTransparent />
+      <S.Thumbnail src={article?.thumbnail || ''} />
+      <Layout withHeader style={{ overflowY: 'hidden' }}>
         <S.Row>
           <S.Keyword bgColor={color500}>{article?.keyword}</S.Keyword>
           <S.Date>{formattedDate(article?.createdAt ?? '')}</S.Date>
@@ -43,7 +42,9 @@ const ArticleDetailPage = () => {
             'data-color-mode': 'light',
           }}
         />
+        <S.EmptyBox />
       </Layout>
+      <S.EmptyBox />
     </>
   );
 };
@@ -51,6 +52,11 @@ const ArticleDetailPage = () => {
 export default ArticleDetailPage;
 
 const S = {
+  Thumbnail: styled.img`
+    width: 100%;
+    height: 25rem;
+    object-fit: cover;
+  `,
   Row: styled.div`
     ${flexSpaceBetween}
   `,
@@ -74,5 +80,8 @@ const S = {
 
     ${title1}
     text-align: center;
+  `,
+  EmptyBox: styled.div`
+    height: 10rem;
   `,
 };

--- a/frontend/src/types/article.ts
+++ b/frontend/src/types/article.ts
@@ -3,6 +3,7 @@ export interface Article {
   keyword: string;
   title: string;
   summary: string;
-  content: string;
+  content?: string;
+  thumbnail: string | null;
   createdAt: string;
 }

--- a/frontend/src/types/article.ts
+++ b/frontend/src/types/article.ts
@@ -4,6 +4,6 @@ export interface Article {
   title: string;
   summary: string;
   content?: string;
-  thumbnail: string | null;
+  thumbnail?: string | null;
   createdAt: string;
 }


### PR DESCRIPTION
## ❗ Issue

- #656 

## ✨ 구현한 기능

### 아티클 디테일 페이지 내부에 대표 이미지가 추가되었습니다. 

추가 요소로 대표이미지가 추가되었습니다. 리스트 내부에도 추가할까 했지만 좁은 아티클 리스트 상 추가할 자리가 없기도 하고 이미지가 그렇게까지 중요한 요소가 아니라서 내부에서만 보여주기로 했습니다. 

**작업한 페이지** 
<img width="413" alt="스크린샷 2024-09-25 오후 2 10 58" src="https://github.com/user-attachments/assets/065e2bd1-8347-484d-b18c-a0abeedb2c39">


### 투명도를 가진 헤더 작업 
페이지 작업을 진행하면서 피그마에 나온대로 투명하면서 아래의 요소를 투영할 수 있는 헤더가 필요하여 작업했습니다. 
`isTransparent`요소를 사용해서 투명도를 가진 헤더를 사용할 수 있으며 선택시 헤더 아래 아이템이 투영됩니다. 
자세한 사항은 위에 사진과 스토리북에서 확인하실 수 있습니다. 


## 📢 논의하고 싶은 내용

## 🎸 기타

