### PR TITLE
[FE] 체크리스트 렌더링 성능을 최적화한다. 

### DIFF
--- a/frontend/src/components/Answer/AnswerIcon.tsx
+++ b/frontend/src/components/Answer/AnswerIcon.tsx
@@ -43,6 +43,3 @@ const AnswerIconMemo = React.memo(AnswerIcon, (prevProps, nextProps) => {
 });
 
 export default AnswerIconMemo;
-//export default React.memo(AnswerIcon);
-
-//return prevProps.isSelected === nextProps.isSelected;

--- a/frontend/src/components/Answer/AnswerIcon.tsx
+++ b/frontend/src/components/Answer/AnswerIcon.tsx
@@ -38,6 +38,6 @@ const AnswerIcon = ({ answer, isSelected = false, ...rest }: Props) => {
   );
 };
 
-const MemoAnswerIcon = React.memo(AnswerIcon);
+const AnswerIconMemo = React.memo(AnswerIcon);
 
-export default MemoAnswerIcon;
+export default AnswerIconMemo;

--- a/frontend/src/components/Answer/AnswerIcon.tsx
+++ b/frontend/src/components/Answer/AnswerIcon.tsx
@@ -38,8 +38,4 @@ const AnswerIcon = ({ answer, isSelected = false, ...rest }: Props) => {
   );
 };
 
-const AnswerIconMemo = React.memo(AnswerIcon, (prevProps, nextProps) => {
-  return prevProps.isSelected === nextProps.isSelected;
-});
-
-export default AnswerIconMemo;
+export default React.memo(AnswerIcon);

--- a/frontend/src/components/Answer/AnswerIcon.tsx
+++ b/frontend/src/components/Answer/AnswerIcon.tsx
@@ -38,6 +38,11 @@ const AnswerIcon = ({ answer, isSelected = false, ...rest }: Props) => {
   );
 };
 
-const AnswerIconMemo = React.memo(AnswerIcon);
+const AnswerIconMemo = React.memo(AnswerIcon, (prevProps, nextProps) => {
+  return prevProps.isSelected === nextProps.isSelected;
+});
 
 export default AnswerIconMemo;
+//export default React.memo(AnswerIcon);
+
+//return prevProps.isSelected === nextProps.isSelected;

--- a/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestion.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestion.tsx
@@ -41,7 +41,10 @@ const ChecklistQuestionItem = ({ answer, question }: Props) => {
   );
 };
 
-const ChecklistQuestionItemMemo = React.memo(ChecklistQuestionItem);
+const ChecklistQuestionItemMemo = React.memo(ChecklistQuestionItem, (prevProps, nextProps) => {
+  return prevProps.answer === nextProps.answer && prevProps.question === nextProps.question;
+});
+
 export default ChecklistQuestionItemMemo;
 
 const S = {

--- a/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestion.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestion.tsx
@@ -27,11 +27,7 @@ const ChecklistQuestionItem = ({ answer, question }: Props) => {
   );
 };
 
-const ChecklistQuestionItemMemo = React.memo(ChecklistQuestionItem, (prevProps, nextProps) => {
-  return prevProps.answer === nextProps.answer && prevProps.question.questionId === nextProps.question.questionId;
-});
-
-export default ChecklistQuestionItemMemo;
+export default React.memo(ChecklistQuestionItem);
 
 const S = {
   Container: styled.div`

--- a/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestion.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestion.tsx
@@ -2,12 +2,9 @@ import styled from '@emotion/styled';
 import React from 'react';
 
 import HighlightText from '@/components/_common/Highlight/HighlightText';
-import { useTabContext } from '@/components/_common/Tabs/TabContext';
-import AnswerIcon from '@/components/Answer/AnswerIcon';
-import { ANSWER_OPTIONS } from '@/constants/answer';
-import useChecklistAnswer from '@/hooks/useChecklistAnswer';
+import ChecklistQuestionAnswers from '@/components/NewChecklist/ChecklistQuestion/ChecklistQuestionAnswers';
 import { flexCenter, flexRow, flexSpaceBetween } from '@/styles/common';
-import { Answer, AnswerType } from '@/types/answer';
+import { AnswerType } from '@/types/answer';
 import { ChecklistQuestion } from '@/types/checklist';
 
 interface Props {
@@ -18,31 +15,20 @@ interface Props {
 const ChecklistQuestionItem = ({ answer, question }: Props) => {
   const { questionId, title, highlights } = question;
 
-  const { updateAndToggleAnswer: updateAnswer } = useChecklistAnswer();
-  const { currentTabId } = useTabContext();
-
-  const handleClick = (newAnswer: AnswerType) => {
-    updateAnswer({ categoryId: currentTabId, questionId: questionId, newAnswer });
-  };
-
   return (
     <S.Container>
       <S.Question>
         <HighlightText title={title} highlights={highlights} />
       </S.Question>
       <S.Options>
-        {ANSWER_OPTIONS.map((option: Answer) => (
-          <div key={option.id} onClick={() => handleClick(option.name)}>
-            <AnswerIcon answer={option.name} isSelected={answer === option.name} />
-          </div>
-        ))}
+        <ChecklistQuestionAnswers answer={answer} questionId={questionId} />
       </S.Options>
     </S.Container>
   );
 };
 
 const ChecklistQuestionItemMemo = React.memo(ChecklistQuestionItem, (prevProps, nextProps) => {
-  return prevProps.answer === nextProps.answer && prevProps.question === nextProps.question;
+  return prevProps.answer === nextProps.answer && prevProps.question.questionId === nextProps.question.questionId;
 });
 
 export default ChecklistQuestionItemMemo;

--- a/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestionAnswers.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestionAnswers.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback } from 'react';
+
+import { useTabContext } from '@/components/_common/Tabs/TabContext';
+import AnswerIcon from '@/components/Answer/AnswerIcon';
+import { ANSWER_OPTIONS } from '@/constants/answer';
+import useChecklistAnswer from '@/hooks/useChecklistAnswer';
+import { Answer, AnswerType } from '@/types/answer';
+
+const ChecklistQuestionAnswers = ({ answer, questionId }: { answer: AnswerType; questionId: number }) => {
+  const { updateAndToggleAnswer: updateAnswer } = useChecklistAnswer();
+  const { currentTabId } = useTabContext();
+
+  const handleClick = useCallback(
+    (newAnswer: AnswerType) => {
+      updateAnswer({ categoryId: currentTabId, questionId: questionId, newAnswer });
+    },
+    [currentTabId, questionId, updateAnswer],
+  );
+
+  return (
+    <>
+      {ANSWER_OPTIONS.map((option: Answer) => {
+        const isSelected = answer === option.name;
+
+        return (
+          <AnswerIcon
+            answer={option.name}
+            isSelected={isSelected}
+            onClick={() => handleClick(option.name)}
+            key={`${questionId}-${option.id}`}
+          />
+        );
+      })}
+    </>
+  );
+};
+
+const ChecklistQuestionAnswersMemo = React.memo(ChecklistQuestionAnswers, (prevProps, nextProps) => {
+  return prevProps.answer === nextProps.answer && prevProps.questionId === nextProps.questionId;
+});
+
+export default ChecklistQuestionAnswersMemo;

--- a/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestionAnswers.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistQuestion/ChecklistQuestionAnswers.tsx
@@ -35,8 +35,4 @@ const ChecklistQuestionAnswers = ({ answer, questionId }: { answer: AnswerType; 
   );
 };
 
-const ChecklistQuestionAnswersMemo = React.memo(ChecklistQuestionAnswers, (prevProps, nextProps) => {
-  return prevProps.answer === nextProps.answer && prevProps.questionId === nextProps.questionId;
-});
-
-export default ChecklistQuestionAnswersMemo;
+export default React.memo(ChecklistQuestionAnswers);

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomName.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomName.tsx
@@ -1,12 +1,16 @@
+import React from 'react';
 import { useStore } from 'zustand';
 
 import FormField from '@/components/_common/FormField/FormField';
+import useDefaultRoomName from '@/components/NewChecklist/NewRoomInfoForm/useDefaultRoomName';
 import checklistRoomInfoStore from '@/store/checklistRoomInfoStore';
 
 const RoomName = () => {
   const actions = useStore(checklistRoomInfoStore, state => state.actions);
   const roomName = useStore(checklistRoomInfoStore, state => state.rawValue.roomName);
   const errorMessage = useStore(checklistRoomInfoStore, state => state.errorMessage.roomName);
+
+  useDefaultRoomName();
 
   return (
     <FormField>
@@ -17,4 +21,4 @@ const RoomName = () => {
   );
 };
 
-export default RoomName;
+export default React.memo(RoomName, () => true);

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomName.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomName.tsx
@@ -21,4 +21,4 @@ const RoomName = () => {
   );
 };
 
-export default React.memo(RoomName, () => true);
+export default React.memo(RoomName);

--- a/frontend/src/components/_common/Highlight/HighlightText.tsx
+++ b/frontend/src/components/_common/Highlight/HighlightText.tsx
@@ -29,9 +29,9 @@ const HighlightText = ({ title, highlights }: Props) => {
   return <S.Title>{highlightText({ title, highlights })}</S.Title>;
 };
 
-const MemoHighlightText = React.memo(HighlightText);
+const HighlightTextMemo = React.memo(HighlightText);
 
-export default MemoHighlightText;
+export default HighlightTextMemo;
 
 const S = {
   Title: styled.div`

--- a/frontend/src/components/_common/Highlight/HighlightText.tsx
+++ b/frontend/src/components/_common/Highlight/HighlightText.tsx
@@ -29,9 +29,7 @@ const HighlightText = ({ title, highlights }: Props) => {
   return <S.Title>{highlightText({ title, highlights })}</S.Title>;
 };
 
-const HighlightTextMemo = React.memo(HighlightText);
-
-export default HighlightTextMemo;
+export default React.memo(HighlightText);
 
 const S = {
   Title: styled.div`

--- a/frontend/src/components/_common/Tabs/Tab.tsx
+++ b/frontend/src/components/_common/Tabs/Tab.tsx
@@ -23,7 +23,7 @@ const Tab = ({ id, onMoveTab, name, active, hasIndicator, className }: Props) =>
   );
 };
 
-const MemoTab = React.memo(Tab, (prevProps, nextProps) => {
+const TabMemo = React.memo(Tab, (prevProps, nextProps) => {
   return (
     prevProps.id === nextProps.id &&
     prevProps.name === nextProps.name &&
@@ -32,7 +32,8 @@ const MemoTab = React.memo(Tab, (prevProps, nextProps) => {
     prevProps.className === nextProps.className
   );
 });
-export default MemoTab;
+
+export default TabMemo;
 
 const S = {
   Container: styled.div<{ active: boolean }>`

--- a/frontend/src/components/_common/Tabs/Tab.tsx
+++ b/frontend/src/components/_common/Tabs/Tab.tsx
@@ -23,17 +23,7 @@ const Tab = ({ id, onMoveTab, name, active, hasIndicator, className }: Props) =>
   );
 };
 
-const TabMemo = React.memo(Tab, (prevProps, nextProps) => {
-  return (
-    prevProps.id === nextProps.id &&
-    prevProps.name === nextProps.name &&
-    prevProps.active === nextProps.active &&
-    prevProps.hasIndicator === nextProps.hasIndicator &&
-    prevProps.className === nextProps.className
-  );
-});
-
-export default TabMemo;
+export default React.memo(Tab);
 
 const S = {
   Container: styled.div<{ active: boolean }>`

--- a/frontend/src/components/_common/Tabs/Tab.tsx
+++ b/frontend/src/components/_common/Tabs/Tab.tsx
@@ -1,6 +1,7 @@
 import '@/styles/category-sprite-image.css';
 
 import styled from '@emotion/styled';
+import React from 'react';
 
 import { flexCenter } from '@/styles/common';
 
@@ -22,7 +23,16 @@ const Tab = ({ id, onMoveTab, name, active, hasIndicator, className }: Props) =>
   );
 };
 
-export default Tab;
+const MemoTab = React.memo(Tab, (prevProps, nextProps) => {
+  return (
+    prevProps.id === nextProps.id &&
+    prevProps.name === nextProps.name &&
+    prevProps.active === nextProps.active &&
+    prevProps.hasIndicator === nextProps.hasIndicator &&
+    prevProps.className === nextProps.className
+  );
+});
+export default MemoTab;
 
 const S = {
   Container: styled.div<{ active: boolean }>`

--- a/frontend/src/components/_common/Tabs/Tabs.tsx
+++ b/frontend/src/components/_common/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useCallback } from 'react';
 
 import Tab from '@/components/_common/Tabs/Tab';
 import { useTabContext } from '@/components/_common/Tabs/TabContext';
@@ -20,9 +21,12 @@ export interface TabWithCompletion extends Tab {
 const Tabs = ({ tabList }: Props) => {
   const { currentTabId, setCurrentTabId } = useTabContext();
 
-  const onMoveTab = (tabId: number) => {
-    setCurrentTabId(tabId);
-  };
+  const onMoveTab = useCallback(
+    (tabId: number) => {
+      setCurrentTabId(tabId);
+    },
+    [setCurrentTabId],
+  );
 
   return (
     <S.VisibleContainer>

--- a/frontend/src/hooks/useChecklistAnswer.ts
+++ b/frontend/src/hooks/useChecklistAnswer.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import useChecklistStore from '@/store/useChecklistStore';
 import { AnswerType } from '@/types/answer';
 import { CategoryAndQuestion } from '@/types/checklist';
@@ -10,42 +12,48 @@ const useChecklistAnswer = () => {
   const checklistActions = useChecklistStore(store => store.actions);
   const checklistCategoryQnA = useChecklistStore(store => store.checklistCategoryQnA);
 
-  const updateAndToggleAnswer = ({ categoryId, questionId, newAnswer }: UpdateAnswerProps) => {
-    const targetCategory = checklistActions.getCategory(categoryId);
+  const updateAndToggleAnswer = useCallback(
+    ({ categoryId, questionId, newAnswer }: UpdateAnswerProps) => {
+      const targetCategory = checklistActions.getCategory(categoryId);
 
-    if (targetCategory) {
-      const updatedCategory = {
-        ...targetCategory,
-        questions: targetCategory.questions.map(question => {
-          if (question.questionId === questionId) {
-            return { ...question, answer: question.answer === newAnswer ? 'NONE' : newAnswer };
-          }
-          return question;
-        }),
-      };
+      if (targetCategory) {
+        const updatedCategory = {
+          ...targetCategory,
+          questions: targetCategory.questions.map(question => {
+            if (question.questionId === questionId) {
+              return { ...question, answer: question.answer === newAnswer ? 'NONE' : newAnswer };
+            }
+            return question;
+          }),
+        };
 
-      const newCategories = checklistCategoryQnA.map(category =>
-        category.categoryId === categoryId ? updatedCategory : category,
-      );
+        const newCategories = checklistCategoryQnA.map(category =>
+          category.categoryId === categoryId ? updatedCategory : category,
+        );
 
-      checklistActions.set(newCategories);
-    }
-  };
+        checklistActions.set(newCategories);
+      }
+    },
+    [checklistActions, checklistCategoryQnA],
+  );
 
-  const findCategoryQuestion = ({ categoryId, questionId }: CategoryAndQuestion) => {
-    const targetCategory = checklistCategoryQnA?.find(category => category.categoryId === categoryId);
+  const findCategoryQuestion = useCallback(
+    ({ categoryId, questionId }: CategoryAndQuestion) => {
+      const targetCategory = checklistCategoryQnA?.find(category => category.categoryId === categoryId);
 
-    if (!targetCategory) {
-      throw new Error(`${categoryId}가 아이디인 카테고리를 찾을 수 없습니다.`);
-    }
+      if (!targetCategory) {
+        throw new Error(`${categoryId}가 아이디인 카테고리를 찾을 수 없습니다.`);
+      }
 
-    const targetQuestion = targetCategory.questions.find(q => q.questionId === questionId);
-    if (!targetQuestion) {
-      throw new Error(`${categoryId}가 아이디인 카테고리 내에서 ${questionId}가 아이디인 질문을 찾을 수 없습니다.`);
-    }
+      const targetQuestion = targetCategory.questions.find(q => q.questionId === questionId);
+      if (!targetQuestion) {
+        throw new Error(`${categoryId}가 아이디인 카테고리 내에서 ${questionId}가 아이디인 질문을 찾을 수 없습니다.`);
+      }
 
-    return targetQuestion;
-  };
+      return targetQuestion;
+    },
+    [checklistCategoryQnA],
+  );
 
   return { updateAndToggleAnswer, findCategoryQuestion };
 };

--- a/frontend/src/hooks/useInitialChecklist.ts
+++ b/frontend/src/hooks/useInitialChecklist.ts
@@ -1,13 +1,10 @@
 import { useEffect } from 'react';
 
-import useDefaultRoomName from '@/components/NewChecklist/NewRoomInfoForm/useDefaultRoomName';
 import useGetChecklistQuestionQuery from '@/hooks/query/useGetChecklistQuestionQuery';
 import useChecklistStore from '@/store/useChecklistStore';
 
 const useInitialChecklist = () => {
   const initAnswerSheetIfEmpty = useChecklistStore(state => state.actions.initAnswerSheetIfEmpty);
-
-  useDefaultRoomName();
 
   const result = useGetChecklistQuestionQuery();
 


### PR DESCRIPTION
## ❗ Issue

- #672 

## ✨ 구현한 기능

- 방 이름 인풋 렌더링 최적화
- 체크리스트 작성할때, 선택한 질문 외에 다른 질문들 렌더링 안되게 최적화
- 선택한 탭 외에 렌더링 안되게 최적화
- 전역 상태를 사용하는 `updateAndToggleAnswer`, `useDefaultRoomName` 를 사용처인 하위 컴포넌트로 내려주어 렌더링이 최대한 작은 범위에서 일어나도록 해주었습니다. 
참고 : zustand 의 상태를 쓰는 컴포넌트들은 memo 를 무시합니다. 이를 최대한 아래에서 사용해주어 최적화를 진행했습니다. 
- 체크리스트 질문 & 답변 컴포넌트가 모두 렌더링 되어, 답변 파트를 `ChecklistQuestionAnswers` 라는 컴포넌트로 나누어주었습니다. `ChecklistQuestionAnswers` 안에서만 store 를 구독하여, 렌더링이 최적화됩니다. 

## 📢 논의하고 싶은 내용

<video width="200" controls>
  <source src="https://github.com/user-attachments/assets/ddf991a0-8daf-4765-af3f-6491db6eb773" type="video/mp4">
</video>


<video width="200" controls>
  <source src="https://github.com/user-attachments/assets/de339942-4e52-4f7f-b75a-e8e6eb865913
" type="video/mp4">
</video>






## 🎸 기타

