### PR TITLE
[FE] 랜딩페이지의 이미지를 preload한다.

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>방끗</title>
     <link href="../src/assets/fonts/SUITE-Variable.woff2" rel="preload" as="style" />
+    <link href="../src/assets/images/category-sprite.webp" rel="preload" as="image" />
+    <link href="../src/assets/images/checkingPageScreen.webp" rel="preload" as="image" />
+    <link href="../src/assets/images/customPageScreen.webp" rel="preload" as="image" />
+    <link href="../src/assets/images/mainPageScreen.webp" rel="preload" as="image" />
     <base href="/" />
   </head>
   <body>


### PR DESCRIPTION
## ❗ Issue

- #684 

## ✨ 구현한 기능
이미지를 preload하였습니다.

사용한 방식 :  index.html의 head태그에 preload를 적용해줬습니다.

검토한 방식
 - index.html head태그에 직접 link preload를 넣어주는방식 : image, css 등 다양한 에셋에 적용가능
 - webpackPreload 로 자동으로 들어가게하는방식 : js상에서 import하는 경우에만 가능.

처음엔 webpackPreload를 우선적으로 검토하였습니다만,
webpackPreload는 (컴포넌트 js)에서만 적극적으로 활용하고
다른경우엔 일단 전자를 써야한다는 판단을 하여 index.html 방식을 적용했습니다.

## 📢 논의하고 싶은 내용



## 🎸 기타

