### PR TITLE
[FE] 전반적인 페이지 UI에 적절한 시맨틱 태그를 적용한다.

### DIFF
--- a/frontend/src/components/ChecklistCustom/QuestionCardList/QuestionCardList.tsx
+++ b/frontend/src/components/ChecklistCustom/QuestionCardList/QuestionCardList.tsx
@@ -27,7 +27,7 @@ const QuestionCardList = ({ questions, currentTabId }: Props) => {
 export default QuestionCardList;
 
 const S = {
-  QuestionList: styled.div`
+  QuestionList: styled.section`
     width: 100%;
     height: fit-content;
     border-radius: 0.8rem;

--- a/frontend/src/components/ChecklistCustom/QuestionListTemplate/QuestionListTemplate.tsx
+++ b/frontend/src/components/ChecklistCustom/QuestionListTemplate/QuestionListTemplate.tsx
@@ -29,7 +29,7 @@ const QuestionListTemplate = () => {
 };
 
 const S = {
-  Container: styled.div`
+  Container: styled.article`
     width: 100%;
     margin-top: 1rem;
     border-radius: 0.8rem;
@@ -39,7 +39,7 @@ const S = {
   Span: styled.div`
     color: ${({ theme }) => theme.palette.grey500};
   `,
-  CounterBox: styled.div`
+  CounterBox: styled.section`
     display: flex;
     padding: 1.2rem;
     justify-content: right;

--- a/frontend/src/components/ChecklistDetail/RoomInfoSection.tsx
+++ b/frontend/src/components/ChecklistDetail/RoomInfoSection.tsx
@@ -129,7 +129,7 @@ const RoomInfoSection = ({ nearSubways, room, options, checklistId, isLiked }: P
 export default RoomInfoSection;
 
 const S = {
-  Container: styled.div`
+  Container: styled.section`
     box-sizing: border-box;
     width: 100%;
     ${flexColumn}

--- a/frontend/src/components/NewChecklist/NewChecklistContent.tsx
+++ b/frontend/src/components/NewChecklist/NewChecklistContent.tsx
@@ -21,7 +21,7 @@ const NewChecklistContent = () => {
 };
 
 const S = {
-  Container: styled.div`
+  Container: styled.main`
     position: relative;
     width: 100%;
     height: 100%;

--- a/frontend/src/components/_common/Accordion/Accordion.tsx
+++ b/frontend/src/components/_common/Accordion/Accordion.tsx
@@ -23,7 +23,7 @@ Accordion.header = AccordionHeader;
 Accordion.body = AccordionBody;
 
 const S = {
-  Container: styled.div<{ width: string }>`
+  Container: styled.section<{ width: string }>`
     ${flexColumn};
     width: ${({ width }) => width};
     gap: 1rem;

--- a/frontend/src/components/_common/Modal/Modal.tsx
+++ b/frontend/src/components/_common/Modal/Modal.tsx
@@ -62,7 +62,7 @@ Modal.body = ModalBody;
 export default Modal;
 
 const S = {
-  ModalWrapper: styled.div<{ open: boolean }>`
+  ModalWrapper: styled.aside<{ open: boolean }>`
     display: ${({ open }) => (open ? 'flex' : 'none')};
     position: fixed;
     z-index: ${({ theme }) => theme.zIndex.MODAL};

--- a/frontend/src/components/_common/Tabs/Tabs.tsx
+++ b/frontend/src/components/_common/Tabs/Tabs.tsx
@@ -58,7 +58,7 @@ const Tabs = ({ tabList }: Props) => {
 export default Tabs;
 
 const S = {
-  VisibleContainer: styled.div`
+  VisibleContainer: styled.nav`
     max-width: 60rem;
   `,
   EmptyBox: styled.div`

--- a/frontend/src/components/_common/TipBox/TipBox.tsx
+++ b/frontend/src/components/_common/TipBox/TipBox.tsx
@@ -25,7 +25,7 @@ const TipBox = ({ tipType }: Props) => {
 };
 
 const S = {
-  TipBox: styled.div`
+  TipBox: styled.article`
     width: 100%;
     ${flexCenter}
     ${flexSpaceBetween}

--- a/frontend/src/components/_common/layout/Layout.tsx
+++ b/frontend/src/components/_common/layout/Layout.tsx
@@ -32,7 +32,7 @@ const Layout = ({
 export default Layout;
 
 const S = {
-  Wrapper: styled.div<{ bgColor: string; withHeader: boolean; withFooter: boolean; withTab: boolean }>`
+  Wrapper: styled.main<{ bgColor: string; withHeader: boolean; withFooter: boolean; withTab: boolean }>`
     box-sizing: border-box;
     overflow: hidden auto;
     ${({ withHeader, withFooter, withTab }) => getHeightStyle(withHeader, withFooter, withTab)}

--- a/frontend/src/components/skeleton/Article/SkArticleList.tsx
+++ b/frontend/src/components/skeleton/Article/SkArticleList.tsx
@@ -26,12 +26,12 @@ const SkArticleList = () => {
 export default SkArticleList;
 
 const S = {
-  Title: styled.div`
+  Title: styled.h1`
     width: 20rem;
     height: 3rem;
     ${Skeleton}
   `,
-  ListContainer: styled.div`
+  ListContainer: styled.section`
     ${flexColumn}
     gap: 1.2rem;
     margin-top: 1.6rem;

--- a/frontend/src/pages/ArticleDetailPage.tsx
+++ b/frontend/src/pages/ArticleDetailPage.tsx
@@ -78,7 +78,7 @@ const S = {
   Date: styled.div`
     font-size: ${({ theme }) => theme.text.size.xSmall};
   `,
-  Title: styled.div`
+  Title: styled.h1`
     margin: 3.6rem;
 
     ${title1}

--- a/frontend/src/pages/ArticleListPage.tsx
+++ b/frontend/src/pages/ArticleListPage.tsx
@@ -38,7 +38,7 @@ const S = {
   Count: styled.span`
     color: ${({ theme }) => theme.palette.green500};
   `,
-  ListContainer: styled.div`
+  ListContainer: styled.section`
     ${flexColumn}
     gap: 1.2rem;
     margin-top: 1.6rem;

--- a/frontend/src/pages/CategoryChoosePage.tsx
+++ b/frontend/src/pages/CategoryChoosePage.tsx
@@ -104,7 +104,7 @@ const S = {
     height: 80dvh;
     padding: 0.4rem;
   `,
-  Content: styled.div`
+  Content: styled.article`
     ${flexColumn}
     gap: 4rem;
   `,

--- a/frontend/src/pages/ChecklistListPage.tsx
+++ b/frontend/src/pages/ChecklistListPage.tsx
@@ -71,7 +71,7 @@ const S = {
     display: flex;
     margin: 1.6rem 0 1rem;
   `,
-  ListBox: styled.div`
+  ListBox: styled.section`
     ${flexColumn}
     gap: 1.2rem;
     overflow-y: scroll;

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -39,7 +39,7 @@ const ErrorPage = () => {
 export default ErrorPage;
 
 const S = {
-  Wrapper: styled.div`
+  Wrapper: styled.article`
     display: flex;
     width: 100%;
     gap: 1rem;

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -55,7 +55,7 @@ const LandingPage = () => {
 export default LandingPage;
 
 const S = {
-  Section: styled.div<{ color: string; height: number }>`
+  Section: styled.section<{ color: string; height: number }>`
     ${flexColumn}
     width: 100%;
     height: ${({ height }) => height}rem;
@@ -64,7 +64,7 @@ const S = {
 
     color: ${({ theme }) => theme.palette.black};
   `,
-  Container: styled.div`
+  Container: styled.main`
     background-color: ${({ theme }) => theme.palette.background};
     ${flexColumn};
   `,

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -21,7 +21,7 @@ const MyPage = () => {
     <>
       <Header center={<Header.Text>마이페이지</Header.Text>} />
       <Layout bgColor={theme.palette.background} withFooter withHeader>
-        <S.Inner>
+        <S.InnerWrapper>
           <S.Container style={{ width: '100%' }}>
             <S.Profile>
               <S.ProfileIcon>
@@ -32,7 +32,7 @@ const MyPage = () => {
           </S.Container>
           {!isError && <Button label="로그아웃" size="full" color="dark" onClick={openModal} />}
           {isError && <Button label="로그인하러 가기" size="full" color="dark" onClick={openModal} />}
-        </S.Inner>
+        </S.InnerWrapper>
       </Layout>
       <LogoutModal isOpen={isModalOpen} onClose={closeModal} />
     </>
@@ -56,7 +56,7 @@ const S = {
     ${flexColumn};
     ${boxShadowSpread}
   `,
-  Inner: styled.div`
+  InnerWrapper: styled.article`
     ${flexCenter}
     ${flexColumn}
   `,


### PR DESCRIPTION
## ❗ Issue

- #726 

## ✨ 구현한 기능

- [x] 페이지마다 시맨틱 태그 적용
- [x] 페이지에서 사용되는 주요 공통컴포넌트 시맨틱태그 적용


#### semantic 분류 기준
 - header
 - main
   - 그 아래 뎁스는 section / article 로 작업하였고, 둘의 구분기준은 '페이지의 맥락에서야 유효한가(section)', '독립적인가(self-contained)' 입니다. 
 - footer
국소적 style을 위한 단순 wrapper은 div를 사용
모달은 aside 사용

아래는 이 기준들을 세우는 데 있어서 참고한 글들 중 일부입니다.

[참고한 MDN - article](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article)
[참고한 MDN - section](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section)
[w3school - semantic](https://www.w3schools.com/html/html5_semantic_elements.asp)

## 📢 논의하고 싶은 내용



## 🎸 기타

