### PR TITLE
[BE] 토큰 관련 코드를 리팩토링한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/config/AuthRequiredPrincipalArgumentResolver.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/config/AuthRequiredPrincipalArgumentResolver.java
@@ -2,8 +2,6 @@ package com.bang_ggood.auth.config;
 
 import com.bang_ggood.auth.controller.CookieResolver;
 import com.bang_ggood.auth.service.AuthService;
-import com.bang_ggood.global.exception.BangggoodException;
-import com.bang_ggood.global.exception.ExceptionCode;
 import com.bang_ggood.user.domain.User;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -35,11 +33,7 @@ public class AuthRequiredPrincipalArgumentResolver implements HandlerMethodArgum
                                 NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        // TODO 리팩토링
-        if (request.getCookies() == null || cookieResolver.isTokenNotExist(request.getCookies())) {
-            throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_EMPTY);
-        }
-
+        cookieResolver.checkLoginRequired(request);
         String token = cookieResolver.extractAccessToken(request.getCookies());
         return authService.getAuthUser(token);
     }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/config/AuthRequiredPrincipalArgumentResolver.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/config/AuthRequiredPrincipalArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.bang_ggood.auth.config;
 
-import com.bang_ggood.auth.controller.CookieResolver;
+import com.bang_ggood.auth.controller.cookie.CookieResolver;
 import com.bang_ggood.auth.service.AuthService;
 import com.bang_ggood.user.domain.User;
 import jakarta.servlet.http.HttpServletRequest;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/config/UserPrincipalArgumentResolver.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/config/UserPrincipalArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.bang_ggood.auth.config;
 
-import com.bang_ggood.auth.controller.CookieResolver;
+import com.bang_ggood.auth.controller.cookie.CookieResolver;
 import com.bang_ggood.auth.service.AuthService;
 import com.bang_ggood.user.domain.User;
 import jakarta.servlet.http.HttpServletRequest;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/config/UserPrincipalArgumentResolver.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/config/UserPrincipalArgumentResolver.java
@@ -33,7 +33,7 @@ public class UserPrincipalArgumentResolver implements HandlerMethodArgumentResol
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
-        if (request.getCookies() == null || cookieResolver.isTokenNotExist(request.getCookies())) {
+        if (cookieResolver.isTokenEmpty(request)) {
             return authService.assignGuestUser();
         }
 

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/AuthController.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.bang_ggood.auth.controller;
 
 import com.bang_ggood.auth.config.AuthRequiredPrincipal;
+import com.bang_ggood.auth.controller.cookie.CookieProvider;
+import com.bang_ggood.auth.controller.cookie.CookieResolver;
 import com.bang_ggood.auth.dto.request.OauthLoginRequest;
 import com.bang_ggood.auth.dto.response.AuthTokenResponse;
 import com.bang_ggood.auth.service.AuthService;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/AuthController.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/AuthController.java
@@ -45,9 +45,11 @@ public class AuthController {
                                        HttpServletRequest httpServletRequest) {
         String accessToken = cookieResolver.extractAccessToken(httpServletRequest.getCookies());
         String refreshToken = cookieResolver.extractRefreshToken(httpServletRequest.getCookies());
+
         authService.logout(accessToken, refreshToken, user);
-        ResponseCookie deletedAccessTokenCookie = cookieProvider.deleteAccessTokenCookie(accessToken);
-        ResponseCookie deletedRefreshTokenCookie = cookieProvider.deleteRefreshTokenCookie(refreshToken);
+
+        ResponseCookie deletedAccessTokenCookie = cookieProvider.deleteAccessTokenCookie();
+        ResponseCookie deletedRefreshTokenCookie = cookieProvider.deleteRefreshTokenCookie();
 
         return ResponseEntity.noContent()
                 .header(HttpHeaders.SET_COOKIE, deletedAccessTokenCookie.toString())
@@ -57,6 +59,8 @@ public class AuthController {
 
     @PostMapping("/accessToken/reissue")
     public ResponseEntity<Void> reIssueAccessToken(HttpServletRequest httpServletRequest) {
+        cookieResolver.checkLoginRequired(httpServletRequest);
+
         String refreshToken = cookieResolver.extractRefreshToken(httpServletRequest.getCookies());
         String accessToken = authService.reIssueAccessToken(refreshToken);
 

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/CookieProvider.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/CookieProvider.java
@@ -9,8 +9,9 @@ import java.time.Duration;
 @Component
 public class CookieProvider {
 
-    public static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
-    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    protected static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    protected static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
     private final JwtTokenProperties jwtTokenProperties;
     private final String domain;
 
@@ -46,11 +47,11 @@ public class CookieProvider {
                 .build();
     }
 
-    public ResponseCookie deleteAccessTokenCookie(String token) {
+    public ResponseCookie deleteAccessTokenCookie() {
         return deleteCookie(ACCESS_TOKEN_COOKIE_NAME);
     }
 
-    public ResponseCookie deleteRefreshTokenCookie(String token) {
+    public ResponseCookie deleteRefreshTokenCookie() {
         return deleteCookie(REFRESH_TOKEN_COOKIE_NAME);
     }
 

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/cookie/CookieProvider.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/cookie/CookieProvider.java
@@ -1,4 +1,4 @@
-package com.bang_ggood.auth.controller;
+package com.bang_ggood.auth.controller.cookie;
 
 import com.bang_ggood.auth.service.jwt.JwtTokenProperties;
 import org.springframework.beans.factory.annotation.Value;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/cookie/CookieResolver.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/controller/cookie/CookieResolver.java
@@ -1,4 +1,4 @@
-package com.bang_ggood.auth.controller;
+package com.bang_ggood.auth.controller.cookie;
 
 import com.bang_ggood.global.exception.BangggoodException;
 import com.bang_ggood.global.exception.ExceptionCode;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/AuthService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.bang_ggood.auth.dto.request.OauthLoginRequest;
 import com.bang_ggood.auth.dto.response.AuthTokenResponse;
 import com.bang_ggood.auth.dto.response.OauthInfoApiResponse;
 import com.bang_ggood.auth.service.jwt.JwtTokenProvider;
+import com.bang_ggood.auth.service.jwt.JwtTokenResolver;
 import com.bang_ggood.auth.service.oauth.OauthClient;
 import com.bang_ggood.global.DefaultChecklistService;
 import com.bang_ggood.global.exception.BangggoodException;
@@ -27,6 +28,7 @@ public class AuthService {
 
     private final OauthClient oauthClient;
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenResolver jwtTokenResolver;
     private final DefaultChecklistService defaultChecklistService;
     private final UserRepository userRepository; // TODO 리팩토링
 
@@ -64,8 +66,8 @@ public class AuthService {
     public void logout(String accessToken, String refreshToken, User user) {
         log.info("logout accessToken: {}", accessToken);
         log.info("logout refreshToken: {}", refreshToken);
-        AuthUser accessAuthUser = jwtTokenProvider.resolveToken(accessToken);
-        AuthUser refreshAuthUser = jwtTokenProvider.resolveToken(refreshToken);
+        AuthUser accessAuthUser = jwtTokenResolver.resolveAccessToken(accessToken);
+        AuthUser refreshAuthUser = jwtTokenResolver.resolveRefreshToken(refreshToken);
         validateTokenOwnership(user, accessAuthUser, refreshAuthUser);
     }
 
@@ -80,17 +82,15 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public User getAuthUser(String token) {
+        AuthUser authUser = jwtTokenResolver.resolveAccessToken(token);
         log.info("extractUser token: {}", token);
-        AuthUser authUser = jwtTokenProvider.resolveToken(token);
         log.info("extractUser authUserId: {}", authUser.id());
         return userRepository.getUserById(authUser.id());
     }
 
     @Transactional(readOnly = true)
     public String reIssueAccessToken(String refreshToken) {
-        jwtTokenProvider.validateRefreshTokenType(refreshToken);
-        AuthUser authUser = jwtTokenProvider.resolveToken(refreshToken);
-
+        AuthUser authUser = jwtTokenResolver.resolveRefreshToken(refreshToken);
         User user = userRepository.getUserById(authUser.id());
         return jwtTokenProvider.createAccessToken(user);
     }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/jwt/JwtTokenProperties.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/jwt/JwtTokenProperties.java
@@ -1,18 +1,24 @@
 package com.bang_ggood.auth.service.jwt;
 
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import javax.crypto.SecretKey;
 
 @Component
 public class JwtTokenProperties {
 
+    protected static final String TOKEN_TYPE = "type";
+
+    private final String secretKey;
     private final long accessTokenExpirationMillis;
     private final long refreshTokenExpirationMillis;
 
     public JwtTokenProperties(
+            @Value("${jwt.secret-key}") String secretKey,
             @Value("${jwt.accessToken-expiration-millis}") long accessTokenExpirationMillis,
             @Value("${jwt.refreshToken-expiration-millis}") long refreshTokenExpirationMillis) {
-
+        this.secretKey = secretKey;
         this.accessTokenExpirationMillis = accessTokenExpirationMillis;
         this.refreshTokenExpirationMillis = refreshTokenExpirationMillis;
     }
@@ -23,5 +29,9 @@ public class JwtTokenProperties {
 
     public long getRefreshTokenExpirationMillis() {
         return refreshTokenExpirationMillis;
+    }
+
+    public SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/jwt/JwtTokenProvider.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/jwt/JwtTokenProvider.java
@@ -1,32 +1,17 @@
 package com.bang_ggood.auth.service.jwt;
 
-import com.bang_ggood.auth.service.AuthUser;
 import com.bang_ggood.auth.service.TokenType;
-import com.bang_ggood.global.exception.BangggoodException;
-import com.bang_ggood.global.exception.ExceptionCode;
 import com.bang_ggood.user.domain.User;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import java.util.Date;
 
+@RequiredArgsConstructor
 @Component
 public class JwtTokenProvider {
 
-    private static final String TOKEN_TYPE = "type";
     private final JwtTokenProperties jwtTokenProperties;
-    private final String secretKey;
-
-    public JwtTokenProvider(
-            @Value("${jwt.secret-key}") String secretKey,
-            JwtTokenProperties jwtTokenProperties) {
-        this.secretKey = secretKey;
-        this.jwtTokenProperties = jwtTokenProperties;
-    }
 
     public String createAccessToken(User user) {
         long accessTokenExpirationMillis = jwtTokenProperties.getAccessTokenExpirationMillis();
@@ -46,39 +31,8 @@ public class JwtTokenProvider {
                 .setSubject(user.getId().toString())
                 .setIssuedAt(now)
                 .setExpiration(expiredDate)
-                .claim(TOKEN_TYPE, tokenType.name())
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .claim(JwtTokenProperties.TOKEN_TYPE, tokenType.name())
+                .signWith(jwtTokenProperties.getSecretKey())
                 .compact();
-    }
-
-    public AuthUser resolveToken(String token) {
-        try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-
-            Long id = Long.valueOf(claims.getSubject());
-            return AuthUser.from(id);
-        } catch (ExpiredJwtException exception) {
-            throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_EXPIRED);
-        } catch (JwtException exception) {
-            throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_INVALID);
-        }
-    }
-
-    public void validateRefreshTokenType(String refreshToken) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .build()
-                .parseClaimsJws(refreshToken)
-                .getBody();
-
-        String tokenType = claims.get(TOKEN_TYPE, String.class);
-
-        if (!tokenType.equals(TokenType.REFRESH_TOKEN.name())) {
-            throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_TYPE_MISMATCH);
-        }
     }
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/jwt/JwtTokenResolver.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/auth/service/jwt/JwtTokenResolver.java
@@ -1,0 +1,53 @@
+package com.bang_ggood.auth.service.jwt;
+
+import com.bang_ggood.auth.service.AuthUser;
+import com.bang_ggood.auth.service.TokenType;
+import com.bang_ggood.global.exception.BangggoodException;
+import com.bang_ggood.global.exception.ExceptionCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenResolver {
+
+    private final JwtTokenProperties jwtTokenProperties;
+
+    public AuthUser resolveAccessToken(String token) {
+        return resolveTokenByType(token, TokenType.ACCESS_TOKEN);
+    }
+
+    public AuthUser resolveRefreshToken(String token) {
+        return resolveTokenByType(token, TokenType.REFRESH_TOKEN);
+    }
+
+    private AuthUser resolveTokenByType(String token, TokenType tokenType) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(jwtTokenProperties.getSecretKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            validateTokenType(claims, tokenType);
+
+            Long id = Long.valueOf(claims.getSubject());
+            return AuthUser.from(id);
+        } catch (ExpiredJwtException exception) {
+            throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_EXPIRED);
+        } catch (JwtException exception) {
+            throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_INVALID);
+        }
+    }
+
+    private void validateTokenType(Claims claims, TokenType tokenType) {
+        String extractTokenType = claims.get(JwtTokenProperties.TOKEN_TYPE, String.class);
+        if (!extractTokenType.equals(tokenType.name())) {
+            throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_TYPE_MISMATCH);
+        }
+    }
+}

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/global/config/WebMvcConfig.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/global/config/WebMvcConfig.java
@@ -1,7 +1,7 @@
 package com.bang_ggood.global.config;
 
 import com.bang_ggood.auth.config.AuthRequiredPrincipalArgumentResolver;
-import com.bang_ggood.auth.controller.CookieResolver;
+import com.bang_ggood.auth.controller.cookie.CookieResolver;
 import com.bang_ggood.auth.config.UserPrincipalArgumentResolver;
 import com.bang_ggood.auth.service.AuthService;
 import org.springframework.context.annotation.Configuration;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/global/exception/ExceptionCode.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/global/exception/ExceptionCode.java
@@ -59,12 +59,11 @@ public enum ExceptionCode {
     LIKE_NOT_EXISTS(HttpStatus.BAD_REQUEST, "체크리스트 좋아요가 존재하지 않아 삭제할 수 없습니다."),
 
     // Auth
-    AUTHENTICATION_COOKIE_EMPTY(HttpStatus.UNAUTHORIZED, "인증정보가 존재하지 않습니다. 쿠키값을 넣어주세요."),
-    AUTHENTICATION_REQUIRED_TOKEN_EMPTY(HttpStatus.UNAUTHORIZED, "토큰 정보가 존재하지 않습니다. 토큰을 재발급해주세요."),
+    AUTHENTICATION_ACCESS_TOKEN_EMPTY(HttpStatus.UNAUTHORIZED, "액세스 토큰이 존재하지 않습니다. 액세스 토큰을 발급해주세요."),
+    AUTHENTICATION_REFRESH_TOKEN_EMPTY(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 존재하지 않습니다. 다시 로그인해주세요."),
     AUTHENTICATION_TOKEN_EMPTY(HttpStatus.UNAUTHORIZED, "로그인이 필요한 사용자입니다."),
     AUTHENTICATION_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     AUTHENTICATION_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰 정보가 올바르지 않습니다."),
-    AUTHENTICATION_TOKEN_IN_BLACKLIST(HttpStatus.UNAUTHORIZED, "이미 로그아웃되어 더 이상 사용할 수 없는 토큰입니다. 다시 로그인 해주세요."),
     AUTHENTICATION_TOKEN_NOT_OWNED_BY_USER(HttpStatus.UNAUTHORIZED, "해당 유저의 토큰이 아닙니다"),
     AUTHENTICATION_TOKEN_USER_MISMATCH(HttpStatus.UNAUTHORIZED, "엑세스 토큰과 리프레시 토큰의 소유자가 다릅니다."),
     AUTHENTICATION_TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "토큰의 타입이 올바르지 않습니다. 리프레시 토큰을 보내주세요."),

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/global/exception/ExceptionCode.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/global/exception/ExceptionCode.java
@@ -66,7 +66,7 @@ public enum ExceptionCode {
     AUTHENTICATION_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰 정보가 올바르지 않습니다."),
     AUTHENTICATION_TOKEN_NOT_OWNED_BY_USER(HttpStatus.UNAUTHORIZED, "해당 유저의 토큰이 아닙니다"),
     AUTHENTICATION_TOKEN_USER_MISMATCH(HttpStatus.UNAUTHORIZED, "엑세스 토큰과 리프레시 토큰의 소유자가 다릅니다."),
-    AUTHENTICATION_TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "토큰의 타입이 올바르지 않습니다. 리프레시 토큰을 보내주세요."),
+    AUTHENTICATION_TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "토큰 타입이 올바르지 않습니다."),
     OAUTH_TOKEN_INTERNAL_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 서버와 통신하는 과정 중 예상치 못한 예외가 발생했습니다."),
     OAUTH_REDIRECT_URI_MISMATCH(HttpStatus.BAD_REQUEST, "일치하는 Redirect URI가 존재하지 않습니다."),
 

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/AcceptanceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/AcceptanceTest.java
@@ -6,10 +6,13 @@ import com.bang_ggood.user.UserFixture;
 import com.bang_ggood.user.domain.User;
 import com.bang_ggood.user.repository.UserRepository;
 import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -28,7 +31,7 @@ public abstract class AcceptanceTest {
     private UserRepository userRepository;
 
     private User authenticatedUser;
-    protected ResponseCookie responseCookie;
+    protected Headers headers;
 
     @LocalServerPort
     private int port;
@@ -45,8 +48,13 @@ public abstract class AcceptanceTest {
 
     private void setResponseCookie() {
         authenticatedUser = userRepository.save(UserFixture.USER1());
-        String token = jwtTokenProvider.createAccessToken(authenticatedUser);
-        responseCookie = cookieProvider.createAccessTokenCookie(token);
+        String accessToken = jwtTokenProvider.createAccessToken(authenticatedUser);
+        String refreshToken = jwtTokenProvider.createRefreshToken(authenticatedUser);
+        ResponseCookie accessTokenResponseCookie = cookieProvider.createAccessTokenCookie(accessToken);
+        ResponseCookie refreshTokenCookie = cookieProvider.createRefreshTokenCookie(refreshToken);
+
+        headers = new Headers(new Header(HttpHeaders.COOKIE, accessTokenResponseCookie.toString()),
+                new Header(HttpHeaders.COOKIE, refreshTokenCookie.toString()));
     }
 
     public User getAuthenticatedUser() {

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/AcceptanceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/AcceptanceTest.java
@@ -1,6 +1,6 @@
 package com.bang_ggood;
 
-import com.bang_ggood.auth.controller.CookieProvider;
+import com.bang_ggood.auth.controller.cookie.CookieProvider;
 import com.bang_ggood.auth.service.jwt.JwtTokenProvider;
 import com.bang_ggood.user.UserFixture;
 import com.bang_ggood.user.domain.User;

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/article/controller/ArticleE2ETest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/article/controller/ArticleE2ETest.java
@@ -9,11 +9,9 @@ import com.bang_ggood.global.exception.ExceptionCode;
 import com.bang_ggood.global.exception.dto.ExceptionResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +25,7 @@ public class ArticleE2ETest extends AcceptanceTest {
     void createArticle() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(ArticleFixture.ARTICLE_CREATE_REQUEST())
                 .when().post("/articles")
                 .then().log().all()
@@ -56,7 +54,7 @@ public class ArticleE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(request)
                 .when().post("/articles")
                 .then().log().all()
@@ -106,7 +104,7 @@ public class ArticleE2ETest extends AcceptanceTest {
         Article article = articleRepository.save(ArticleFixture.ARTICLE());
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().delete("/articles/" + article.getId())
                 .then().log().all()
                 .statusCode(204);

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/auth/JwtTokenFixture.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/auth/JwtTokenFixture.java
@@ -5,16 +5,16 @@ import com.bang_ggood.auth.service.jwt.JwtTokenProvider;
 import java.security.SecureRandom;
 import java.util.Base64;
 
-public class JwtTokenProviderFixture {
+public class JwtTokenFixture {
 
     private static final long THIRTY_MINUTE = 1800000L;
 
     public static JwtTokenProvider JWT_TOKEN_PROVIDER_WITH_INVALID_KEY() {
-        return new JwtTokenProvider(createInvalidJwtSecretKey(), PROPERTIES());
+        return new JwtTokenProvider(PROPERTIES_WITH_INVALID_SECRET_KEY());
     }
 
     public static JwtTokenProvider JWT_TOKEN_PROVIDER_WITH_INVALID_EXPIRED_TIME() {
-        return new JwtTokenProvider(createJwtSecretKey(), PROPERTIES_WITH_SHORT_EXPIRED_MILLIS());
+        return new JwtTokenProvider(PROPERTIES_WITH_SHORT_EXPIRED_MILLIS());
     }
 
     private static String createJwtSecretKey() {
@@ -24,15 +24,11 @@ public class JwtTokenProviderFixture {
         return Base64.getEncoder().encodeToString(key);
     }
 
-    private static String createInvalidJwtSecretKey() {
-        return "A".repeat(32);
-    }
-
     private static JwtTokenProperties PROPERTIES_WITH_SHORT_EXPIRED_MILLIS() {
-        return new JwtTokenProperties(1L, 1L);
+        return new JwtTokenProperties(createJwtSecretKey(), 1L, 1L);
     }
 
-    private static JwtTokenProperties PROPERTIES() {
-        return new JwtTokenProperties(THIRTY_MINUTE , THIRTY_MINUTE);
+    private static JwtTokenProperties PROPERTIES_WITH_INVALID_SECRET_KEY() {
+        return new JwtTokenProperties(createJwtSecretKey(), THIRTY_MINUTE , THIRTY_MINUTE);
     }
 }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/auth/config/ArgumentResolverTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/auth/config/ArgumentResolverTest.java
@@ -1,7 +1,7 @@
 package com.bang_ggood.auth.config;
 
 import com.bang_ggood.AcceptanceTest;
-import com.bang_ggood.auth.controller.CookieProvider;
+import com.bang_ggood.auth.controller.cookie.CookieProvider;
 import com.bang_ggood.global.exception.ExceptionCode;
 import com.bang_ggood.user.UserFixture;
 import com.bang_ggood.user.domain.User;

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/auth/config/ArgumentResolverTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/auth/config/ArgumentResolverTest.java
@@ -46,7 +46,7 @@ class ArgumentResolverTest extends AcceptanceTest {
         // given & when
         User user = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().get(TestController.USER_PRINCIPAL_URL)
                 .then().log().all()
                 .statusCode(200)

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/auth/controller/CookieResolverTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/auth/controller/CookieResolverTest.java
@@ -3,9 +3,13 @@ package com.bang_ggood.auth.controller;
 import com.bang_ggood.global.exception.BangggoodException;
 import com.bang_ggood.global.exception.ExceptionCode;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class CookieResolverTest {
 
@@ -39,7 +43,7 @@ class CookieResolverTest {
         Assertions.assertThat(token).isEqualTo(expectedToken);
     }
 
-    @DisplayName("쿠키에서 토큰 값 조회 실패 : 토큰 값이 존재하지 않을 때")
+    @DisplayName("쿠키에서 토큰 값 조회 실패 : 액세스 토큰 값이 존재하지 않을 때")
     @Test
     void tokenValueNotExist() {
         // given
@@ -50,7 +54,7 @@ class CookieResolverTest {
         // when & then
         Assertions.assertThatThrownBy(() -> cookieResolver.extractAccessToken(cookies))
                 .isInstanceOf(BangggoodException.class)
-                .hasMessage(ExceptionCode.AUTHENTICATION_REQUIRED_TOKEN_EMPTY.getMessage());
+                .hasMessage(ExceptionCode.AUTHENTICATION_ACCESS_TOKEN_EMPTY.getMessage());
 
     }
 
@@ -59,11 +63,13 @@ class CookieResolverTest {
     void isAllTokenNotExist_returnFalse() {
         // given
         CookieResolver cookieResolver = new CookieResolver();
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         Cookie[] cookies =  { new Cookie(CookieProvider.ACCESS_TOKEN_COOKIE_NAME, "test"),
                 new Cookie(CookieProvider.REFRESH_TOKEN_COOKIE_NAME, "test")};
 
         // when
-        boolean result = cookieResolver.isTokenNotExist(cookies);
+        when(httpServletRequest.getCookies()).thenReturn(cookies);
+        boolean result = cookieResolver.isTokenEmpty(httpServletRequest);
 
         // then
         Assertions.assertThat(result).isFalse();
@@ -71,13 +77,16 @@ class CookieResolverTest {
 
     @DisplayName("쿠키 존재 여부 반환 성공 : 액세스 & 리프레시 토큰 정보가 존재하지 않으면 true를 반환한다.")
     @Test
-    void isTokenNotExist_returnTrue() {
+    void isTokenEmpty_returnTrue() {
         // given
         CookieResolver cookieResolver = new CookieResolver();
-        Cookie[] cookies =  { new Cookie("test", "test") };
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        Cookie[] cookies =  { new Cookie("test", "test"),
+                new Cookie("test", "test")};
 
         // when
-        boolean result = cookieResolver.isTokenNotExist(cookies);
+        when(httpServletRequest.getCookies()).thenReturn(cookies);
+        boolean result = cookieResolver.isTokenEmpty(httpServletRequest);
 
         // then
         Assertions.assertThat(result).isTrue();
@@ -85,13 +94,15 @@ class CookieResolverTest {
 
     @DisplayName("쿠키 존재 여부 반환 성공 : 토큰 정보가 하나라도 존재하지 않으면 false를 반환한다.")
     @Test
-    void isTokenNotExist_returnFalse() {
+    void isTokenNotEmpty_returnFalse() {
         // given
         CookieResolver cookieResolver = new CookieResolver();
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         Cookie[] cookies =  { new Cookie(CookieProvider.ACCESS_TOKEN_COOKIE_NAME, "test")};
 
         // when
-        boolean result = cookieResolver.isTokenNotExist(cookies);
+        when(httpServletRequest.getCookies()).thenReturn(cookies);
+        boolean result = cookieResolver.isTokenEmpty(httpServletRequest);
 
         // then
         Assertions.assertThat(result).isFalse();

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/auth/controller/cookie/CookieResolverTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/auth/controller/cookie/CookieResolverTest.java
@@ -1,5 +1,7 @@
-package com.bang_ggood.auth.controller;
+package com.bang_ggood.auth.controller.cookie;
 
+import com.bang_ggood.auth.controller.cookie.CookieProvider;
+import com.bang_ggood.auth.controller.cookie.CookieResolver;
 import com.bang_ggood.global.exception.BangggoodException;
 import com.bang_ggood.global.exception.ExceptionCode;
 import jakarta.servlet.http.Cookie;

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/auth/controller/cookie/LoginMockE2ETest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/auth/controller/cookie/LoginMockE2ETest.java
@@ -1,6 +1,7 @@
-package com.bang_ggood.auth.controller;
+package com.bang_ggood.auth.controller.cookie;
 
 import com.bang_ggood.AcceptanceMockTestSupport;
+import com.bang_ggood.auth.controller.cookie.CookieProvider;
 import com.bang_ggood.auth.dto.request.OauthLoginRequest;
 import com.bang_ggood.auth.dto.response.AuthTokenResponse;
 import com.bang_ggood.auth.service.AuthService;

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/auth/service/JwtTokenProviderTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/auth/service/JwtTokenProviderTest.java
@@ -1,8 +1,9 @@
 package com.bang_ggood.auth.service;
 
 import com.bang_ggood.IntegrationTestSupport;
-import com.bang_ggood.auth.JwtTokenProviderFixture;
+import com.bang_ggood.auth.JwtTokenFixture;
 import com.bang_ggood.auth.service.jwt.JwtTokenProvider;
+import com.bang_ggood.auth.service.jwt.JwtTokenResolver;
 import com.bang_ggood.global.exception.BangggoodException;
 import com.bang_ggood.global.exception.ExceptionCode;
 import com.bang_ggood.user.UserFixture;
@@ -16,6 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 class JwtTokenProviderTest extends IntegrationTestSupport {
 
     @Autowired
+    private JwtTokenResolver jwtTokenResolver;
+    @Autowired
     private JwtTokenProvider jwtTokenProvider;
     @Autowired
     private UserRepository userRepository;
@@ -28,38 +31,23 @@ class JwtTokenProviderTest extends IntegrationTestSupport {
         String token = jwtTokenProvider.createAccessToken(user);
 
         // when
-        AuthUser authUser = jwtTokenProvider.resolveToken(token);
+        AuthUser authUser = jwtTokenResolver.resolveAccessToken(token);
 
         // then
         Assertions.assertThat(authUser.id()).isEqualTo(user.getId());
-    }
-
-    @DisplayName("토큰 획인 실패 : 유효시간이 지난 경우")
-    @Test
-    void resolveToken_expiredTime_exception() {
-        // given
-        JwtTokenProvider expiredJwtTokenProvider = JwtTokenProviderFixture.JWT_TOKEN_PROVIDER_WITH_INVALID_EXPIRED_TIME();
-
-        User user = userRepository.save(UserFixture.USER1());
-        String token = expiredJwtTokenProvider.createAccessToken(user);
-
-        // when & then
-        Assertions.assertThatCode(() -> expiredJwtTokenProvider.resolveToken(token))
-                .isInstanceOf(BangggoodException.class)
-                .hasMessage(ExceptionCode.AUTHENTICATION_TOKEN_EXPIRED.getMessage());
     }
 
     @DisplayName("토큰 확인 실패 : 시그니처가 잘못된 경우")
     @Test
     void resolveToken_invalidSignature_exception() {
         // given
-        JwtTokenProvider invalidJwtTokenProvider = JwtTokenProviderFixture.JWT_TOKEN_PROVIDER_WITH_INVALID_KEY();
+        JwtTokenProvider invalidJwtTokenProvider = JwtTokenFixture.JWT_TOKEN_PROVIDER_WITH_INVALID_KEY();
 
         User user = userRepository.save(UserFixture.USER1());
-        String token = jwtTokenProvider.createAccessToken(user);
+        String token = invalidJwtTokenProvider.createAccessToken(user);
 
         // when & then
-        Assertions.assertThatCode(() -> invalidJwtTokenProvider.resolveToken(token))
+        Assertions.assertThatCode(() -> jwtTokenResolver.resolveAccessToken(token))
                 .isInstanceOf(BangggoodException.class)
                 .hasMessage(ExceptionCode.AUTHENTICATION_TOKEN_INVALID.getMessage());
     }
@@ -71,7 +59,7 @@ class JwtTokenProviderTest extends IntegrationTestSupport {
         String invalidToken = "malformed";
 
         // when & then
-        Assertions.assertThatCode(() -> jwtTokenProvider.resolveToken(invalidToken))
+        Assertions.assertThatCode(() -> jwtTokenResolver.resolveAccessToken(invalidToken))
                 .isInstanceOf(BangggoodException.class)
                 .hasMessage(ExceptionCode.AUTHENTICATION_TOKEN_INVALID.getMessage());
     }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/controller/ChecklistE2ETest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/controller/ChecklistE2ETest.java
@@ -14,11 +14,9 @@ import com.bang_ggood.room.domain.Room;
 import com.bang_ggood.room.repository.RoomRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -42,7 +40,7 @@ class ChecklistE2ETest extends AcceptanceTest {
     void createChecklist() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(ChecklistFixture.CHECKLIST_CREATE_REQUEST())
                 .when().post("/checklists")
                 .then().log().all()
@@ -54,7 +52,7 @@ class ChecklistE2ETest extends AcceptanceTest {
     void createChecklist_noRoomName_exception() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(ChecklistFixture.CHECKLIST_CREATE_REQUEST_NO_ROOM_NAME())
                 .when().post("/checklists")
                 .then().log().all()
@@ -67,7 +65,7 @@ class ChecklistE2ETest extends AcceptanceTest {
     void createChecklist_noQuestionId_exception() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(ChecklistFixture.CHECKLIST_CREATE_REQUEST_NO_QUESTION_ID())
                 .when().post("/checklists")
                 .then().log().all()
@@ -84,7 +82,7 @@ class ChecklistE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().get("/checklists/questions")
                 .then().log().all()
                 .statusCode(200);
@@ -98,7 +96,7 @@ class ChecklistE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().get("/checklists/" + checklistId)
                 .then().log().all()
                 .statusCode(200);
@@ -117,7 +115,7 @@ class ChecklistE2ETest extends AcceptanceTest {
     void readLikedUserChecklistsPreview() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().get("/checklists/like")
                 .then().log().all()
                 .statusCode(200);
@@ -131,7 +129,7 @@ class ChecklistE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(ChecklistFixture.CHECKLIST_UPDATE_REQUEST())
                 .when().put("/checklists/" + checklistId)
                 .then().log().all()
@@ -146,7 +144,7 @@ class ChecklistE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(ChecklistFixture.CHECKLIST_UPDATE_REQUEST_NO_ROOM_NAME())
                 .when().put("/checklists/" + checklistId)
                 .then().log().all()
@@ -162,7 +160,7 @@ class ChecklistE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(ChecklistFixture.CHECKLIST_UPDATE_REQUEST_NO_QUESTION_ID())
                 .when().put("/checklists/" + checklistId)
                 .then().log().all()
@@ -179,7 +177,7 @@ class ChecklistE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().delete("/checklists/" + saved.getId())
                 .then().log().all()
                 .statusCode(204);

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/like/controller/ChecklistLikeE2ETest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/like/controller/ChecklistLikeE2ETest.java
@@ -12,11 +12,9 @@ import com.bang_ggood.room.domain.Room;
 import com.bang_ggood.room.repository.RoomRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 
 class ChecklistLikeE2ETest extends AcceptanceTest {
 
@@ -39,7 +37,7 @@ class ChecklistLikeE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().post("/checklists/" + checklistId + "/like")
                 .then().log().all()
                 .statusCode(204);
@@ -54,7 +52,7 @@ class ChecklistLikeE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().post("/checklists/" + checklistId + "/like")
                 .then().log().all()
                 .statusCode(409);
@@ -70,7 +68,7 @@ class ChecklistLikeE2ETest extends AcceptanceTest {
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().delete("/checklists/" + checklist.getId() + "/like")
                 .then().log().all()
                 .statusCode(204);

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/controller/QuestionE2ETest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/controller/QuestionE2ETest.java
@@ -4,10 +4,8 @@ import com.bang_ggood.AcceptanceTest;
 import com.bang_ggood.question.CustomChecklistFixture;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 
 class QuestionE2ETest extends AcceptanceTest {
 
@@ -16,7 +14,7 @@ class QuestionE2ETest extends AcceptanceTest {
     void readCustomChecklistQuestions() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().get("/checklists/questions")
                 .then().log().all()
                 .statusCode(200);
@@ -27,7 +25,7 @@ class QuestionE2ETest extends AcceptanceTest {
     void readAllCustomChecklistQuestion() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().get("/custom-checklist/all")
                 .then().log().all()
                 .statusCode(200);
@@ -38,7 +36,7 @@ class QuestionE2ETest extends AcceptanceTest {
     void updateCustomChecklist() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .body(CustomChecklistFixture.CUSTOM_CHECKLIST_UPDATE_REQUEST())
                 .when().put("/custom-checklist")
                 .then().log().all()

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/user/controller/UserE2ETest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/user/controller/UserE2ETest.java
@@ -5,10 +5,8 @@ import com.bang_ggood.user.domain.User;
 import com.bang_ggood.user.dto.UserResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.restassured.http.Header;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -21,7 +19,7 @@ class UserE2ETest extends AcceptanceTest {
         User user = this.getAuthenticatedUser();
         UserResponse response = RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(new Header(HttpHeaders.COOKIE, this.responseCookie.toString()))
+                .headers(this.headers)
                 .when().get("/user/me")
                 .then().log().all()
                 .statusCode(200)


### PR DESCRIPTION
## ❗ Issue

- #747 

## ✨ 구현한 기능

- [토큰 에러 메시지](https://www.notion.so/6b6798854e3e46c9adaac96d33b4ca8f) 적용
  - 액세스 토큰과 리프레시 토큰의 에러 메시지를 다르게 하기 위해 리팩토링을 진행했습니다.
  
- TODO로 남겨둔 부분 리팩토링
  - 토큰이 존재하는지 검증하는 부분이 ```1) null 체크, 2) 토큰 유무 체크``` 이렇게 if문내에 존재했는데 실수하기 쉬운 코드라고 생각했습니다. 하나의 메소드에서 검증이 가능하도록 리팩토링했습니다. 
```java
// TODO 리팩토링 전
if (request.getCookies() == null || cookieResolver.isTokenNotExist(request.getCookies())) {
    throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_EMPTY);
}

// 리팩토링 후
public void checkLoginRequired(HttpServletRequest request) {
      if (isTokenEmpty(request)) {
          throw new BangggoodException(ExceptionCode.AUTHENTICATION_TOKEN_EMPTY);
      }

      if (isRefreshTokenEmpty(request.getCookies())) {
          throw new BangggoodException(ExceptionCode.AUTHENTICATION_REFRESH_TOKEN_EMPTY);
      }
  }
```

- RefreshToken이 도입되면서 JwtTokenProvider의 책임이 많아져 JwtTokenResolver를 생성하고 역할을 분리했습니다.

## 📢 논의하고 싶은 내용

## 🎸 기타
- 이외 작업하면서 no-usage인 코드 제거했습니다.
