### PR TITLE
[FE] playwright를 CI 설정한다.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,7 +1,9 @@
 name: Playwright Tests
 on:
   pull_request:
-    branches: [main, dev-fe]
+    branches: [dev, dev-fe]
+    paths:
+      - "frontend/**"
 jobs:
   test:
     timeout-minutes: 10
@@ -27,6 +29,5 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: frontend/playwright-report/
           retention-days: 30
-        working-directory: frontend

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,13 +1,18 @@
 name: Playwright Tests
 on:
   pull_request:
-    branches: [dev, dev-fe]
+    branches: [main, dev-fe]
+    paths:
+      - "frontend/**"
+  push:
+    branches: [main, dev-fe]
     paths:
       - "frontend/**"
 jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    environment: frontend-msw
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,6 +30,22 @@ jobs:
         run: |
           cd frontend
           yarn playwright install --with-deps
+      - name: Create .env File
+          run: |
+            cd frontend
+            echo "CLIENT_ID=${{ secrets.CLIENT_ID }}" >> .env
+            echo "GA_ID=${{ secrets.GA_ID }}" >> .env
+            echo "COOKIE=${{ secrets.COOKIE }}" >> .env
+            echo "KAKAO_MAP_KEY=${{ secrets.KAKAO_MAP_KEY }}" >> .env
+            echo "SENTRY_DSN_TOKEN=${{ secrets.SENTRY_DSN_TOKEN }}" >> .env
+            echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env
+            echo "SENTRY_ORG=${{ secrets.SENTRY_ORG }}" >> .env
+            echo "SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}" >> .env
+            echo "ANALYZE_BUNDLE=${{ secrets.ANALYZE_BUNDLE }}" >> .env
+            echo "CI=${{ secrets.CI }}" >> .env
+            echo "API_ENV=${{ secrets.API_ENV }}" >> .env
+            echo "API_URL=${{ secrets.API_URL }}" >> .env
+            echo "REDIRECT_URI=${{ secrets.REDIRECT_URI }}" >> .env
       - name: Run Playwright tests
         run: |
           cd frontend

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,11 +12,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 20
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          cd frontend 
-          npm install -g yarn && yarn
+          cd frontend
+          yarn install --frozen-lockfile
       - name: Install Playwright Browsers
         run: |
           cd frontend

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,21 +31,21 @@ jobs:
           cd frontend
           yarn playwright install --with-deps
       - name: Create .env File
-          run: |
-            cd frontend
-            echo "CLIENT_ID=${{ secrets.CLIENT_ID }}" >> .env
-            echo "GA_ID=${{ secrets.GA_ID }}" >> .env
-            echo "COOKIE=${{ secrets.COOKIE }}" >> .env
-            echo "KAKAO_MAP_KEY=${{ secrets.KAKAO_MAP_KEY }}" >> .env
-            echo "SENTRY_DSN_TOKEN=${{ secrets.SENTRY_DSN_TOKEN }}" >> .env
-            echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env
-            echo "SENTRY_ORG=${{ secrets.SENTRY_ORG }}" >> .env
-            echo "SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}" >> .env
-            echo "ANALYZE_BUNDLE=${{ secrets.ANALYZE_BUNDLE }}" >> .env
-            echo "CI=${{ secrets.CI }}" >> .env
-            echo "API_ENV=${{ secrets.API_ENV }}" >> .env
-            echo "API_URL=${{ secrets.API_URL }}" >> .env
-            echo "REDIRECT_URI=${{ secrets.REDIRECT_URI }}" >> .env
+        run: |
+          cd frontend
+          echo "CLIENT_ID=${{ secrets.CLIENT_ID }}" >> .env
+          echo "GA_ID=${{ secrets.GA_ID }}" >> .env
+          echo "COOKIE=${{ secrets.COOKIE }}" >> .env
+          echo "KAKAO_MAP_KEY=${{ secrets.KAKAO_MAP_KEY }}" >> .env
+          echo "SENTRY_DSN_TOKEN=${{ secrets.SENTRY_DSN_TOKEN }}" >> .env
+          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> .env
+          echo "SENTRY_ORG=${{ secrets.SENTRY_ORG }}" >> .env
+          echo "SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}" >> .env
+          echo "ANALYZE_BUNDLE=${{ secrets.ANALYZE_BUNDLE }}" >> .env
+          echo "CI=${{ secrets.CI }}" >> .env
+          echo "API_ENV=${{ secrets.API_ENV }}" >> .env
+          echo "API_URL=${{ secrets.API_URL }}" >> .env
+          echo "REDIRECT_URI=${{ secrets.REDIRECT_URI }}" >> .env
       - name: Run Playwright tests
         run: |
           cd frontend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,7 +8,7 @@ npm run build
 
 or
 
-```
+```a
 yarn build
 ```
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://127.0.0.1:3000',
+    baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -72,9 +72,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'yarn msw',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    actionTimeout: 20000, // await 타임아웃 :  5초로 설정
+    actionTimeout: 5000, // await 타임아웃 :  5초로 설정
   },
 
   /* Configure projects for major browsers */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    actionTimeout: 5000, // await 타임아웃 :  5초로 설정
+    actionTimeout: 20000, // await 타임아웃 :  5초로 설정
   },
 
   /* Configure projects for major browsers */
@@ -73,8 +73,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'yarn msw',
-    url: 'http://localhost:3000',
+    command: 'yarn msw -- --no-open',
+    url: 'http://localhost:3000/',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/frontend/src/e2e/newChecklist.spec.ts
+++ b/frontend/src/e2e/newChecklist.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
 
 test('빈 체크리스트를 제출할 수 있다.', async ({ page }) => {
-  await page.goto('http://localhost:3000/');
+  await page.goto('/');
   await page.getByRole('button', { name: '방끗 둘러보기' }).click();
   await page.getByRole('button', { name: '전체 보기' }).click();
   await page.getByLabel('add').click();


### PR DESCRIPTION
## ❗ Issue

- #772 

## ✨ 구현한 기능
## PR시 (`main`,`dev-fe`에 PR 또는 push 시) e2e테스트 작동하게 설정

### 깃헙 액션에서  **의존성 설치 캐싱** 이용해 46초 감소 (총 준비 시간 : `1분 30초 -> 40초`)

의존성 설치 캐싱 적용전 (49초)
![image](https://github.com/user-attachments/assets/3c6221c3-a2eb-4d2e-b2f9-a6405e3b34d4)

의존성 설치 캐싱 적용후 (10초 (준비 5초, 본작업 0초, 마무리5초))
![image](https://github.com/user-attachments/assets/f55a30cc-f58f-4c4f-8812-f53a97026a1f)

나름의 최적화를 했는데도 기본준비시간이 40초이고
작은테스트 하나(3개) 돌아가는데 40초 정도 걸리네요.


브라우저 설치(36초. 아래그림참고) 도 캐싱하려하였으나,
playwright 공식문서에서 이를권장하지 않아 적용하지않았습니다.

### 환경변수 주입 위해 깃헙 environments 추가
![image](https://github.com/user-attachments/assets/60d39c79-97fe-4d23-9a2b-814ad20983ec)
기존 : e2e테스트를 돌리려면 환경변수가 필요한데 깃헙액션이 없었음.
변경 :
frontend-msw환경을 만들면 action상에서 secrets변수로 받아올수있기때문에 추가.
액션에서 이걸 받아와 .env 파일로 만들어서 사용.

#### frontend 라는 하위폴더 구성에맞게 yml 구성

### 현재 CI 상태
![image](https://github.com/user-attachments/assets/8678d98b-7a9d-4270-8907-c4e99cb567b1)


## 📢 논의하고 싶은 내용


## 🎸 기타

CI 동작을 확인하면서 작업했어야해서 밑에 깃헙액션 코멘트가 많습니다.