### PR TITLE
[BE] 질문이 없는 카테고리는 보내지 않도록 수정한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistManageService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistManageService.java
@@ -148,9 +148,9 @@ public class ChecklistManageService {
     private List<SelectedCategoryQuestionsResponse> readChecklistQuestions(Checklist checklist) {
         List<ChecklistQuestion> checklistQuestions = checklistQuestionService.readChecklistQuestions(checklist);
 
-
         return questionService.findAllCategories().stream()
                 .map(category -> categorizeChecklistQuestions(category, checklistQuestions))
+                .filter(selectedCategoryQuestionsResponse -> !selectedCategoryQuestionsResponse.questions().isEmpty())
                 .toList();
     }
 

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/repository/CategoryRepository.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/repository/CategoryRepository.java
@@ -2,6 +2,16 @@ package com.bang_ggood.question.repository;
 
 import com.bang_ggood.question.domain.CategoryEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<CategoryEntity, Integer> {
+
+    @Query(value = "SELECT distinct c.* FROM category c "
+            + "JOIN question q ON q.category_id = c.id "
+            + "JOIN custom_checklist_question ccq ON ccq.question_id = q.id "
+            + "WHERE ccq.user_id = :id AND ccq.deleted = false ",
+            nativeQuery = true)
+    List<CategoryEntity> findAllCustomQuestionCategoriesById(@Param("id") Long id);
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/repository/CategoryRepository.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/repository/CategoryRepository.java
@@ -11,7 +11,7 @@ public interface CategoryRepository extends JpaRepository<CategoryEntity, Intege
     @Query(value = "SELECT distinct c.* FROM category c "
             + "JOIN question q ON q.category_id = c.id "
             + "JOIN custom_checklist_question ccq ON ccq.question_id = q.id "
-            + "WHERE ccq.user_id = :id AND ccq.deleted = false ",
+            + "WHERE ccq.user_id = :userId AND ccq.deleted = false ",
             nativeQuery = true)
-    List<CategoryEntity> findAllCustomQuestionCategoriesById(@Param("id") Long id);
+    List<CategoryEntity> findAllCustomQuestionCategoriesByUserId(@Param("userId") Long userId);
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionManageService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionManageService.java
@@ -38,16 +38,19 @@ public class QuestionManageService {
     public CustomChecklistQuestionsResponse readCustomChecklistQuestions(User user) {
         List<CustomChecklistQuestion> customChecklistQuestions = checklistQuestionService.readCustomChecklistQuestions(
                 user);
-        List<CategoryQuestionsResponse> categoryQuestionsResponses = categorizeCustomChecklistQuestions(
-                customChecklistQuestions);
+        List<CategoryQuestionsResponse> categoryQuestionsResponses = categorizeCustomChecklistQuestions(user, customChecklistQuestions).stream()
+                .filter(categoryQuestionsResponse -> !categoryQuestionsResponse.questions().isEmpty())
+                .toList();
+
         return new CustomChecklistQuestionsResponse(categoryQuestionsResponses);
     }
 
     private List<CategoryQuestionsResponse> categorizeCustomChecklistQuestions(
+            User user,
             List<CustomChecklistQuestion> customChecklistQuestions) {
         List<CategoryQuestionsResponse> categoryQuestionsResponses = new ArrayList<>();
 
-        for (CategoryEntity category : questionService.findAllCategories()) {
+        for (CategoryEntity category : questionService.findAllCustomQuestionCategories(user)) {
             List<QuestionResponse> questionResponses = customChecklistQuestions.stream()
                     .filter(customChecklistQuestion -> customChecklistQuestion.getCategory().getName().equals(category.getName())) // TODO 리팩토링
                     .map(customChecklistQuestion -> new QuestionResponse(customChecklistQuestion.getQuestion()))

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionService.java
@@ -24,7 +24,7 @@ public class QuestionService {
 
     @Transactional(readOnly = true)
     public List<CategoryEntity> findAllCustomQuestionCategories(User user) {
-        return categoryRepository.findAllCustomQuestionCategoriesById(user.getId());
+        return categoryRepository.findAllCustomQuestionCategoriesByUserId(user.getId());
     }
 
     @Transactional(readOnly = true)

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionService.java
@@ -4,6 +4,7 @@ import com.bang_ggood.question.domain.CategoryEntity;
 import com.bang_ggood.question.domain.QuestionEntity;
 import com.bang_ggood.question.repository.CategoryRepository;
 import com.bang_ggood.question.repository.QuestionRepository;
+import com.bang_ggood.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,11 @@ public class QuestionService {
     @Transactional(readOnly = true)
     public List<CategoryEntity> findAllCategories() {
         return categoryRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryEntity> findAllCustomQuestionCategories(User user) {
+        return categoryRepository.findAllCustomQuestionCategoriesById(user.getId());
     }
 
     @Transactional(readOnly = true)

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/CustomChecklistFixture.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/CustomChecklistFixture.java
@@ -16,8 +16,8 @@ public class CustomChecklistFixture {
 
 
     public static List<CustomChecklistQuestion> CUSTOM_CHECKLIST_QUESTION_DEFAULT(User user) {
-        return List.of(new CustomChecklistQuestion(user, Question.ROOM_CONDITION_1, QuestionFixture.QUESTION1),
-                new CustomChecklistQuestion(user, Question.WINDOW_1, QuestionFixture.QUESTION2));
+        return List.of(new CustomChecklistQuestion(user, Question.ROOM_CONDITION_1, QuestionFixture.QUESTION1_CATEGORY1),
+                new CustomChecklistQuestion(user, Question.WINDOW_1, QuestionFixture.QUESTION3_CATEGORY2));
     }
 
     public static CustomChecklistUpdateRequest CUSTOM_CHECKLIST_UPDATE_REQUEST() {
@@ -40,7 +40,7 @@ public class CustomChecklistFixture {
     }
 
     public static void init() {
-        CUSTOM_CHECKLIST_QUESTION_DEFAULT = List.of(new CustomChecklistQuestion(UserFixture.USER1, Question.ROOM_CONDITION_1, QuestionFixture.QUESTION1),
-                new CustomChecklistQuestion(UserFixture.USER1, Question.WINDOW_1, QuestionFixture.QUESTION2));
+        CUSTOM_CHECKLIST_QUESTION_DEFAULT = List.of(new CustomChecklistQuestion(UserFixture.USER1, Question.ROOM_CONDITION_1, QuestionFixture.QUESTION1_CATEGORY1),
+                new CustomChecklistQuestion(UserFixture.USER1, Question.WINDOW_1, QuestionFixture.QUESTION2_CATEGORY1));
     }
 }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/QuestionFixture.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/QuestionFixture.java
@@ -7,13 +7,17 @@ import com.bang_ggood.question.repository.QuestionRepository;
 
 public class QuestionFixture {
 
-    public static QuestionEntity QUESTION1;
-    public static QuestionEntity QUESTION2;
+    public static QuestionEntity QUESTION1_CATEGORY1;
+    public static QuestionEntity QUESTION2_CATEGORY1;
+    public static QuestionEntity QUESTION3_CATEGORY2;
     public static CategoryEntity CATEGORY1;
+    public static CategoryEntity CATEGORY2;
 
     public static void init(CategoryRepository categoryRepository, QuestionRepository questionRepository) {
-        CATEGORY1 = categoryRepository.save(new CategoryEntity("testCategory"));
-        QUESTION1 = questionRepository.save(new QuestionEntity(CATEGORY1, "testTitle1", "testSubTitle1", true));
-        QUESTION2 = questionRepository.save(new QuestionEntity(CATEGORY1, "testTitle2", "testSubTitle2", true));
+        CATEGORY1 = categoryRepository.save(new CategoryEntity("방 컨디션"));
+        CATEGORY2 = categoryRepository.save(new CategoryEntity("창문"));
+        QUESTION1_CATEGORY1 = questionRepository.save(new QuestionEntity(CATEGORY1, "testTitle1", "testSubTitle1", true));
+        QUESTION2_CATEGORY1 = questionRepository.save(new QuestionEntity(CATEGORY1, "testTitle2", "testSubTitle2", true));
+        QUESTION3_CATEGORY2 = questionRepository.save(new QuestionEntity(CATEGORY2, "testTitle3", "testSubTitle3", true));
     }
 }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/CategoryRepositoryTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/CategoryRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.bang_ggood.question.repository;
+
+import com.bang_ggood.IntegrationTestSupport;
+import com.bang_ggood.question.QuestionFixture;
+import com.bang_ggood.question.domain.CategoryEntity;
+import com.bang_ggood.question.domain.CustomChecklistQuestion;
+import com.bang_ggood.question.domain.Question;
+import com.bang_ggood.user.UserFixture;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
+
+class CategoryRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private CustomChecklistQuestionRepository customChecklistQuestionRepository;
+
+    @DisplayName("카테고리 조회 성공 : 커스텀 체크리스트 카테고리 조회")
+    @Test
+    void findAllById() {
+        //given
+        int expectedCategory = 2;
+        CustomChecklistQuestion customChecklistQuestion1 = new CustomChecklistQuestion(
+                UserFixture.USER1,
+                Question.ROOM_CONDITION_1,
+                QuestionFixture.QUESTION1_CATEGORY1);
+        CustomChecklistQuestion customChecklistQuestion2 = new CustomChecklistQuestion(
+                UserFixture.USER1,
+                Question.ROOM_CONDITION_2,
+                QuestionFixture.QUESTION2_CATEGORY1);
+        CustomChecklistQuestion customChecklistQuestion3 = new CustomChecklistQuestion(
+                UserFixture.USER1,
+                Question.ROOM_CONDITION_1,
+                QuestionFixture.QUESTION3_CATEGORY2);
+        customChecklistQuestionRepository.saveAll(List.of(customChecklistQuestion1, customChecklistQuestion2, customChecklistQuestion3));
+
+        // when
+        List<CategoryEntity> categories = categoryRepository.findAllCustomQuestionCategoriesById(UserFixture.USER1.getId());
+
+        // then
+        Assertions.assertThat(categories)
+                .hasSize(expectedCategory)
+                .containsOnly(QuestionFixture.CATEGORY1, QuestionFixture.CATEGORY2);
+    }
+}

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/CategoryRepositoryTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/CategoryRepositoryTest.java
@@ -39,7 +39,7 @@ class CategoryRepositoryTest extends IntegrationTestSupport {
         customChecklistQuestionRepository.saveAll(List.of(customChecklistQuestion1, customChecklistQuestion2, customChecklistQuestion3));
 
         // when
-        List<CategoryEntity> categories = categoryRepository.findAllCustomQuestionCategoriesById(UserFixture.USER1.getId());
+        List<CategoryEntity> categories = categoryRepository.findAllCustomQuestionCategoriesByUserId(UserFixture.USER1.getId());
 
         // then
         Assertions.assertThat(categories)

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/ChecklistQuestionRepositoryTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/ChecklistQuestionRepositoryTest.java
@@ -43,8 +43,8 @@ class ChecklistQuestionRepositoryTest extends IntegrationTestSupport {
         User user = userRepository.save(UserFixture.USER1());
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
-        checklistQuestionRepository.save(ChecklistQuestionFixture.CHECKLIST1_QUESTION1(checklist, QuestionFixture.QUESTION1));
-        checklistQuestionRepository.save(ChecklistQuestionFixture.CHECKLIST1_QUESTION2(checklist, QuestionFixture.QUESTION2));
+        checklistQuestionRepository.save(ChecklistQuestionFixture.CHECKLIST1_QUESTION1(checklist, QuestionFixture.QUESTION1_CATEGORY1));
+        checklistQuestionRepository.save(ChecklistQuestionFixture.CHECKLIST1_QUESTION2(checklist, QuestionFixture.QUESTION2_CATEGORY1));
 
         // when
         List<ChecklistQuestion> checklistQuestions = checklistQuestionRepository.findAllByChecklistId(
@@ -65,13 +65,13 @@ class ChecklistQuestionRepositoryTest extends IntegrationTestSupport {
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
         ChecklistQuestion checklistQuestion1 = checklistQuestionRepository.save(
-                ChecklistQuestionFixture.CHECKLIST1_QUESTION1(checklist, QuestionFixture.QUESTION1));
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION1(checklist, QuestionFixture.QUESTION1_CATEGORY1));
         ChecklistQuestion checklistQuestion2 = checklistQuestionRepository.save(
-                ChecklistQuestionFixture.CHECKLIST1_QUESTION2(checklist, QuestionFixture.QUESTION2));
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION2(checklist, QuestionFixture.QUESTION2_CATEGORY1));
 
         //when
         checklistQuestionRepository.deleteAllByChecklistId(
-                ChecklistQuestionFixture.CHECKLIST1_QUESTION1(checklist, QuestionFixture.QUESTION1).getChecklistId());
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION1(checklist, QuestionFixture.QUESTION1_CATEGORY1).getChecklistId());
 
         //then
         assertAll(

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/service/ChecklistQuestionServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/service/ChecklistQuestionServiceTest.java
@@ -58,7 +58,7 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
         User user = userRepository.save(UserFixture.USER1());
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
-        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1, QuestionFixture.QUESTION2);
+        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1_CATEGORY1, QuestionFixture.QUESTION2_CATEGORY1);
 
         //when
         checklistQuestionService.createQuestions(checklistQuestions);
@@ -76,7 +76,7 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
         User user = userRepository.save(UserFixture.USER1());
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
-        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_DUPLICATE(checklist, QuestionFixture.QUESTION1);
+        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_DUPLICATE(checklist, QuestionFixture.QUESTION1_CATEGORY1);
 
         // when & then
         assertThatThrownBy(
@@ -94,8 +94,8 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
         List<ChecklistQuestion> checklistQuestions = List.of(
-                ChecklistQuestionFixture.CHECKLIST1_QUESTION1(checklist, QuestionFixture.QUESTION1),
-                ChecklistQuestionFixture.CHECKLIST1_QUESTION2(checklist, QuestionFixture.QUESTION2)
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION1(checklist, QuestionFixture.QUESTION1_CATEGORY1),
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION2(checklist, QuestionFixture.QUESTION2_CATEGORY1)
         );
         checklistQuestionService.createQuestions(checklistQuestions);
 
@@ -115,11 +115,11 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
         User user = userRepository.save(UserFixture.USER1());
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
-        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1, QuestionFixture.QUESTION2);
+        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1_CATEGORY1, QuestionFixture.QUESTION2_CATEGORY1);
         checklistQuestionService.createQuestions(checklistQuestions);
 
         //when
-        List<ChecklistQuestion> updateQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS_UPDATE(checklist, QuestionFixture.QUESTION1, QuestionFixture.QUESTION2);
+        List<ChecklistQuestion> updateQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS_UPDATE(checklist, QuestionFixture.QUESTION1_CATEGORY1, QuestionFixture.QUESTION2_CATEGORY1);
         checklistQuestionService.updateQuestions(checklistQuestions, updateQuestions);
 
         //then
@@ -135,11 +135,11 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
         User user = userRepository.save(UserFixture.USER1());
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
-        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1, QuestionFixture.QUESTION2);
+        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1_CATEGORY1, QuestionFixture.QUESTION2_CATEGORY1);
         checklistQuestionService.createQuestions(checklistQuestions);
 
         //when & then
-        List<ChecklistQuestion> updateQuestions = ChecklistQuestionFixture.CHECKLIST1_DUPLICATE(checklist, QuestionFixture.QUESTION1);
+        List<ChecklistQuestion> updateQuestions = ChecklistQuestionFixture.CHECKLIST1_DUPLICATE(checklist, QuestionFixture.QUESTION1_CATEGORY1);
         assertThatThrownBy(
                 () -> checklistQuestionService.updateQuestions(checklistQuestions, updateQuestions))
                 .isInstanceOf(BangggoodException.class)
@@ -154,12 +154,12 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
         User user = userRepository.save(UserFixture.USER1());
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
-        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1, QuestionFixture.QUESTION2);
+        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1_CATEGORY1, QuestionFixture.QUESTION2_CATEGORY1);
         checklistQuestionService.createQuestions(checklistQuestions);
 
         //when & then
         List<ChecklistQuestion> updateQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS_DIFFERENT_LENGTH(
-                checklist, QuestionFixture.QUESTION1);
+                checklist, QuestionFixture.QUESTION1_CATEGORY1);
         assertThatThrownBy(
                 () -> checklistQuestionService.updateQuestions(checklistQuestions, updateQuestions))
                 .isInstanceOf(BangggoodException.class)
@@ -174,12 +174,12 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
         User user = userRepository.save(UserFixture.USER1());
 
         Checklist checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
-        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1, QuestionFixture.QUESTION2);
+        List<ChecklistQuestion> checklistQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS(checklist, QuestionFixture.QUESTION1_CATEGORY1, QuestionFixture.QUESTION2_CATEGORY1);
         checklistQuestionService.createQuestions(checklistQuestions);
 
         //when & then
         List<ChecklistQuestion> updateQuestions = ChecklistQuestionFixture.CHECKLIST1_QUESTIONS_DIFFERENT_QUESTION(
-                checklist, QuestionFixture.QUESTION2, QuestionFixture.QUESTION1);
+                checklist, QuestionFixture.QUESTION2_CATEGORY1, QuestionFixture.QUESTION1_CATEGORY1);
         assertThatThrownBy(
                 () -> checklistQuestionService.updateQuestions(checklistQuestions, updateQuestions))
                 .isInstanceOf(BangggoodException.class)
@@ -191,8 +191,8 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
     void readCustomChecklistQuestions() {
         // given
         User user = userRepository.save(UserFixture.USER1());
-        CustomChecklistQuestion question1 = new CustomChecklistQuestion(user, Question.ROOM_CONDITION_5, QuestionFixture.QUESTION1);
-        CustomChecklistQuestion question2 = new CustomChecklistQuestion(user, Question.BATHROOM_1, QuestionFixture.QUESTION2);
+        CustomChecklistQuestion question1 = new CustomChecklistQuestion(user, Question.ROOM_CONDITION_5, QuestionFixture.QUESTION1_CATEGORY1);
+        CustomChecklistQuestion question2 = new CustomChecklistQuestion(user, Question.BATHROOM_1, QuestionFixture.QUESTION2_CATEGORY1);
         List<CustomChecklistQuestion> questions = List.of(question1, question2);
         customChecklistQuestionRepository.saveAll(questions);
 


### PR DESCRIPTION
## ❗ Issue

- #841 

## ✨ 구현한 기능

- 카테고리 전달시 질문이 없는 카테고리는 보내지 않는다.
  - 예시 ) 아래의 경우 제외하고 보낸다.
```java
{
            "categoryId": 5,
            "categoryName": "외부",
            "questions": []
}
```
## 📢 논의하고 싶은 내용

## 🎸 기타

- 현재 로직에서 DTO에서 필터링하는 방식도 생각해봤으나 해당 방식으로 작업하면 실수할 가능성이 크다고 생각해 카테고리 조회방식을 바꾸도록 구현했습니다.
- nativeQuery 사용부분은 JPQL 사용으로 변경하고 싶은데 쿼리 실행이 잘 되지 않아 이대로 PR제출합니다. 해결방법있다면 알려주세요!