### PR TITLE
[BE] 회원가입 시 필요한 로직을 추가한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/user/repository/UserRepository.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/user/repository/UserRepository.java
@@ -34,4 +34,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("UPDATE User u SET u.deleted = true WHERE u.id = :id")
     void deleteById(@Param("id") Long id);
 
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE User u SET u.deleted = false WHERE u.email = :email AND u.loginType = :loginType")
+    void resaveByEmailAndLoginType(@Param("email") Email email, @Param("loginType") LoginType loginType);
+
+    @Query("SELECT u FROM User u WHERE u.email = :email and u.loginType = :loginType")
+    Optional<User> findByEmailAndLoginTypeWithDeleted(Email email, LoginType loginType);
 }


### PR DESCRIPTION
## ❗ Issue
- #845 

## ✨ 구현한 기능
- 회원가입 시 예시용 체크리스트를 만든다
- 회원가입 시 커스텀 체크리스트 데이터를 초기화한다
- 회원가입 시 탈퇴했던 회원인지 확인한다

## 📢 논의하고 싶은 내용
카카오 로그인 시에는 최초 가입 회원 가입, 기존 회원 로그인, 탈퇴 회원 재가입 플로우입니다.
일반 회원가입 시에는 최초 가입 회원 가입, 기존 회원 예외 발생, 탈퇴 회원 재가입 플로우입니다.


## 🎸 기타

