### PR TITLE
[FE] QA 피드백 이후 체크리스트 디테일 페이지 UI/UX 를 개선한다.

### DIFF
--- a/frontend/src/components/ChecklistDetail/RoomInfoSection.tsx
+++ b/frontend/src/components/ChecklistDetail/RoomInfoSection.tsx
@@ -16,7 +16,7 @@ import LikeButton from '@/components/_common/Like/LikeButton';
 import AddressMap from '@/components/_common/Map/AddressMap';
 import SubwayStations from '@/components/_common/Subway/SubwayStations';
 import { IncludedMaintenancesData } from '@/constants/roomInfo';
-import { flexColumn, flexRow, flexSpaceBetween, title2 } from '@/styles/common';
+import { flexColumn, flexRow, flexSpaceBetween, title2, title3, title4 } from '@/styles/common';
 import { ChecklistInfo } from '@/types/checklist';
 import { Option } from '@/types/option';
 import { RoomInfo } from '@/types/room';
@@ -61,6 +61,7 @@ const RoomInfoSection = ({ checklist, nearSubways, room, options, checklistId, i
           <S.Title>{roomName}</S.Title>
           <LikeButton isLiked={isLiked} checklistId={checklistId} />
         </S.Row>
+
         <S.Row>
           <S.MoneyText>
             <div>
@@ -70,59 +71,106 @@ const RoomInfoSection = ({ checklist, nearSubways, room, options, checklistId, i
           </S.MoneyText>
         </S.Row>
       </S.GreenWrapper>
-      <S.GapBox>
-        <S.Row>
-          <Room aria-label="방 구조" />
-          {formattedUndefined(structure, 'string', '방 구조')} / {formattedUndefined(size)} 평
-        </S.Row>
-        <S.Row>
-          <Stairs aria-label="방 종류" />
-          {floorLevel === '지상'
-            ? `${formattedUndefined(floor)}층`
-            : formattedUndefined(floorLevel, 'string', '방 종류')}
-        </S.Row>
-      </S.GapBox>
+
       <S.Row>
-        <Utils aria-label="관리비 포함 항목" /> 관리비 포함 항목 :
-        {includedMaintenances
-          ?.map(id => IncludedMaintenancesData.find(item => item.id === id)?.displayName)
-          .filter(Boolean)
-          .join(', ')}
-        {!includedMaintenances?.length && formattedUndefined(includedMaintenances?.length, 'string', '')}
+        <S.Label>
+          <Summary aria-label="한줄평" />
+          한줄평
+        </S.Label>
+        <S.Text>{formattedUndefined(summary, 'string')}</S.Text>
       </S.Row>
+
       <S.Row>
-        <Calendar aria-label="계약 월수 / 입주 가능일" />
-        {formattedUndefined(contractTerm)}개월 계약 <br />
-        입주 가능일 : {formattedUndefined(occupancyMonth)}월 {occupancyPeriod}
+        <S.Label>
+          <Pencil aria-label="작성 일자" />방 둘러본 날
+        </S.Label>
+        <S.Text>{formattedDate(createdAt ?? '', '.')}</S.Text>
       </S.Row>
+
       <S.Row>
-        <Subway aria-label="가까운 지하철" />
-        <SubwayStations stations={nearSubways} checklist={checklist} />
+        <S.Label>
+          <Room aria-label="방 구조 / 방 평수" />
+          방 구조 <br />/ 방 평수
+        </S.Label>
+        <S.Text>
+          {formattedUndefined(structure, 'string')} <br />/ {formattedUndefined(size)} 평
+        </S.Text>
       </S.Row>
-      <S.GapBox>
-        <S.Row>
+
+      <S.Row>
+        <S.Label>
+          <Stairs aria-label="방 층수" />방 층수
+        </S.Label>
+        <S.Text>
+          {floorLevel === '지상' ? `${formattedUndefined(floor)}층` : formattedUndefined(floorLevel, 'string')}
+        </S.Text>
+      </S.Row>
+
+      <S.Row>
+        <S.Label>
+          <Utils aria-label="관리비 포함 항목" />
+          관리비 포함 항목
+        </S.Label>
+        <S.Text>
+          {includedMaintenances
+            ?.map(id => IncludedMaintenancesData.find(item => item.id === id)?.displayName)
+            .filter(Boolean)
+            .join(', ')}
+          {!includedMaintenances?.length && formattedUndefined(includedMaintenances?.length, 'string')}
+        </S.Text>
+      </S.Row>
+
+      <S.Row>
+        <S.Label>
+          <Calendar aria-label="계약 기간 / 입주 가능일" />
+          계약 기간 <br />/ 입주 가능일
+        </S.Label>
+        <S.Text>
+          {formattedUndefined(contractTerm)}개월 계약 <br />/{formattedUndefined(occupancyMonth)}월 {occupancyPeriod}
+        </S.Text>
+      </S.Row>
+
+      <S.Row>
+        <S.Label>
+          <Options aria-label="옵션" />
+          옵션
+        </S.Label>
+        <S.Text>
+          {options.length
+            ? options.map(option => option.optionName).join(', ')
+            : formattedUndefined(options.length, 'string')}
+        </S.Text>
+      </S.Row>
+
+      <S.Row>
+        <S.Label>
           <Building aria-label="부동산" />
-          {formattedUndefined(realEstate, 'string', '부동산')}
-        </S.Row>
-        <S.Row>
-          <Pencil aria-label="작성 일자" />
-          {formattedDate(createdAt ?? '', '.')}
-        </S.Row>
-      </S.GapBox>
-      <S.Row>
-        <Options aria-label="옵션" />
-        {options.length
-          ? options.map(option => option.optionName).join(', ')
-          : formattedUndefined(options.length, 'string', '옵션')}
+          부동산
+        </S.Label>
+        <S.Text>{formattedUndefined(realEstate, 'string')}</S.Text>
       </S.Row>
-      <S.Row>
-        <Summary aria-label="한줄평" />
-        {formattedUndefined(summary, 'string', '한줄평')}
-      </S.Row>
-      <S.Row>
-        <LocationLineIcon height={20} width={20} aria-label="주소" />
-        {formattedUndefined(address, 'string', '주소')} <br /> {buildingName}
-      </S.Row>
+
+      <S.Column>
+        <S.Label>
+          <LocationLineIcon height={20} width={20} aria-label="주소" />
+          주소
+        </S.Label>
+        <S.Text>
+          {formattedUndefined(address, 'string')} <br />
+          {buildingName}
+        </S.Text>
+      </S.Column>
+
+      <S.Column>
+        <S.Label>
+          <Subway aria-label="가까운 지하철" />
+          가까운 지하철
+        </S.Label>
+        <S.Text>
+          <SubwayStations stations={nearSubways} checklist={checklist} />
+        </S.Text>
+      </S.Column>
+
       <AddressMap location={address ?? ''} />
     </S.Container>
   );
@@ -149,12 +197,29 @@ const S = {
     background-color: ${({ theme }) => theme.palette.green500};
 
     color: ${({ theme }) => theme.palette.white};
-    font-size: ${({ theme }) => theme.text.size.medium};
+    font-size: ${({ theme }) => theme.text.size.small};
     box-sizing: border-box;
     border-radius: 1.6rem;
   `,
-  Row: styled.div`
+  Label: styled.div`
+    width: 100%;
     ${flexRow}
+    gap: 1rem;
+
+    font-weight: ${({ theme }) => theme.text.weight.bold};
+  `,
+  Text: styled.div`
+    ${flexRow}
+    width: 100%;
+  `,
+  Row: styled.div`
+    width: 100%;
+    ${flexRow}
+    gap: 1rem;
+  `,
+  Column: styled.div`
+    width: 100%;
+    ${flexColumn}
     gap: 1rem;
   `,
   GapBox: styled.div`
@@ -174,7 +239,8 @@ const S = {
   MoneyText: styled.div`
     width: 100%;
 
-    font-size: ${({ theme }) => theme.text.size.small};
+    /* ${title4} */
+    ${title3}
     ${flexRow}
     ${flexSpaceBetween}
   `,

--- a/frontend/src/components/ChecklistList/ChecklistCard.tsx
+++ b/frontend/src/components/ChecklistList/ChecklistCard.tsx
@@ -25,7 +25,7 @@ const ChecklistCard = ({ checklist }: Props) => {
       <S.Row>
         <S.LocationWrapper>
           <LocationLineIcon aria-hidden="true" />
-          {formattedUndefined(address, 'string', '주소')}
+          {formattedUndefined(address, 'string')}
         </S.LocationWrapper>
         <LikeButton isLiked={isLiked} checklistId={checklistId} />
       </S.Row>
@@ -37,7 +37,7 @@ const ChecklistCard = ({ checklist }: Props) => {
       </S.Column>
       <S.Row>
         <S.SummaryWrapper>
-          <S.SummaryBox>{`"${formattedUndefined(summary, 'string', '한줄평')}"`}</S.SummaryBox>
+          <S.SummaryBox>{`"${formattedUndefined(summary, 'string')}"`}</S.SummaryBox>
         </S.SummaryWrapper>
         <S.Date>{formattedDate(createdAt ?? '')}</S.Date>
       </S.Row>

--- a/frontend/src/components/_common/Subway/SubwayStations.tsx
+++ b/frontend/src/components/_common/Subway/SubwayStations.tsx
@@ -27,6 +27,6 @@ export default SubwayStations;
 const S = {
   Box: styled.div`
     ${flexColumn};
-    gap: 1rem;
+    gap: .5rem;
   `,
 };

--- a/frontend/src/components/_common/layout/Layout.tsx
+++ b/frontend/src/components/_common/layout/Layout.tsx
@@ -36,7 +36,7 @@ const S = {
     box-sizing: border-box;
     overflow: hidden auto;
     ${({ withHeader, withFooter, withTab }) => getHeightStyle(withHeader, withFooter, withTab)}
-    padding: 1.6rem;
+    padding: 1rem 1.6rem;
 
     background-color: ${({ bgColor }) => bgColor};
   `,

--- a/frontend/src/utils/formattedUndefined.ts
+++ b/frontend/src/utils/formattedUndefined.ts
@@ -1,10 +1,10 @@
 type ValueType = 'string' | 'number';
 
-const formattedUndefined = (value: string | number | undefined, type: ValueType = 'number', valueTitle?: string) => {
+const formattedUndefined = (value: string | number | undefined, type: ValueType = 'number') => {
   if (value) return value;
 
   if (type === 'number') return '-';
-  return `${valueTitle} 정보 없음`;
+  return `없음`;
 };
 
 export default formattedUndefined;


### PR DESCRIPTION
## ❗ Issue

- #894 

## ✨ 구현한 기능

### 디테일 페이지 UI/UX 개선 작업 진행했습니다. 
지난번 QA 진행 중 나온 이야기로 디테일 페이지 가독성이 좋지 않다고 다수의 건의가 나와서 개선 작업 진행했습니다. 
텍스트가 많은 페이지를 감안하여 텍스트를 나열하는 상세 정보 페이지들을 레퍼런스 삼아 개선했습니다. 
아래에 비포 에프터 참조하겠습니다. 

### 개선 전 
<img width="395" alt="스크린샷 2024-10-24 오후 9 39 18" src="https://github.com/user-attachments/assets/a6823018-4ee2-401f-b339-e82e1ade229a3">

### 개선 후 
<img width="395" alt="스크린샷 2024-10-24 오후 9 39 18" src="https://github.com/user-attachments/assets/8fa402e4-32cc-46de-be94-75d027496a03">


## 📢 논의하고 싶은 내용



## 🎸 기타

