### PR TITLE
[FE] 메인페이지에 주소가없을때 역이름이 선릉역8분으로 뜨던에러를해결한다.

### DIFF
--- a/frontend/src/components/Main/ChecklistPreviewCard.tsx
+++ b/frontend/src/components/Main/ChecklistPreviewCard.tsx
@@ -26,7 +26,7 @@ const ChecklistPreviewCard = ({ index, checklist }: Props) => {
 
   const stationLabel = address
     ? `${formattedUndefined(station?.stationName)}역 · ${formattedUndefined(station?.walkingTime)}분`
-    : '-역 · -분'; // TODO: address없을시 역이름에 선릉역을 넣었다가 버그생김. 임시해결을위해 address를검사하고있지만, 제대로된방법을 쓰도록고쳐야함.
+    : '-역 · -분'; // TODO: address없을시 역이름에 선릉역을 넣었다가 버그생김. 임시해결을위해 address를 검사하고있지만, 제대로된방법을 쓰도록고쳐야함.
 
   return (
     <S.Container onClick={handleClick} tabIndex={1}>

--- a/frontend/src/components/Main/ChecklistPreviewCard.tsx
+++ b/frontend/src/components/Main/ChecklistPreviewCard.tsx
@@ -18,19 +18,21 @@ const ChecklistPreviewCard = ({ index, checklist }: Props) => {
   const colorList = ['green', 'blue', 'red'];
   const { color200, color500 } = getSeqColor(index, colorList);
 
-  const { checklistId, station, roomName, deposit, rent } = checklist;
+  const { checklistId, station, roomName, deposit, rent, address } = checklist;
 
   const handleClick = () => {
     navigate(ROUTE_PATH.checklistOne(checklistId));
   };
 
+  const stationLabel = address
+    ? `${formattedUndefined(station?.stationName)}역 · ${formattedUndefined(station?.walkingTime)}분`
+    : '-역 · -분'; // TODO: address없을시 역이름에 선릉역을 넣었다가 버그생김. 임시해결을위해 address를검사하고있지만, 제대로된방법을 쓰도록고쳐야함.
+
   return (
     <S.Container onClick={handleClick} tabIndex={1}>
       <HomeCircle color={color500} bgColor={color200} aria-hidden="true" />
       <S.Column>
-        <S.Label>
-          {formattedUndefined(station?.stationName)}역 · {formattedUndefined(station?.walkingTime)}분
-        </S.Label>
+        <S.Label>{stationLabel}</S.Label>
         <S.Row>
           <S.Title>{roomName}</S.Title>
           <div>


### PR DESCRIPTION
## ❗ Issue

- #908

## ✨ 구현한 기능

데이터가없어도 메인페이지에서 선릉역 8분뜨던에러해결

### 적용전 (데이터가없는데 선릉역 8분뜸)
![image](https://github.com/user-attachments/assets/e14dc366-522b-4f35-b11b-d24ddcb09461)

### 적용후 (-역 -분으로 뜸)
![image](https://github.com/user-attachments/assets/16877cbf-1c29-4ec4-b1cf-64adf73260d1)


## 📢 논의하고 싶은 내용



## 🎸 기타

