### PR TITLE
[FE] swipe 기능을 ref를 받아 쓰도록 개선한다

### DIFF
--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -35,19 +35,18 @@ export const deleteToken = async () => {
 };
 
 export const postReissueAccessToken = async () => {
-  return await fetch(`${BASE_URL}${ENDPOINT.USER_ACCESS_TOKEN_REISSUE}`, {
-    method: 'POST',
+  return await fetcher.post({
+    url: `${BASE_URL}${ENDPOINT.USER_ACCESS_TOKEN_REISSUE}`,
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    // 쿠키전달이기때문에 body가 비어있는 post
   });
 };
 
 export const postSignUp = async ({ name, email, password }: { name: string; email: string; password: string }) => {
-  return await fetch(`${BASE_URL}${ENDPOINT.REGISTER}`, {
-    method: 'POST',
-    body: JSON.stringify({ name, email, password }),
+  return await fetcher.post({
+    url: `${BASE_URL}${ENDPOINT.REGISTER}`,
+    body: { name, email, password },
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
   });
 };
 

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -47,6 +47,7 @@ export const postSignUp = async ({ name, email, password }: { name: string; emai
     method: 'POST',
     body: JSON.stringify({ name, email, password }),
     credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
   });
 };
 

--- a/frontend/src/components/EditChecklist/ChecklistContent/EditChecklistContent.tsx
+++ b/frontend/src/components/EditChecklist/ChecklistContent/EditChecklistContent.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Suspense } from 'react';
+import { Suspense, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import ListErrorFallback from '@/components/_common/errorBoundary/ListErrorFallback';
@@ -7,12 +7,29 @@ import { useTabContext } from '@/components/_common/Tabs/TabContext';
 import EditChecklistQuestionTemplate from '@/components/EditChecklist/ChecklistContent/EditChecklistQuestionTemplate';
 import RoomInfoTemplate from '@/components/NewChecklist/NewRoomInfoForm/RoomInfoTemplate';
 import OptionTemplate from '@/components/NewChecklist/Option/OptionTemplate';
+import { DefaultChecklistTabsNames } from '@/constants/tabs';
+import useMouseDrag from '@/hooks/useMouseDrag';
 
 const EditChecklistContent = () => {
   const { currentTabId } = useTabContext();
 
+  const { setCurrentTabId } = useTabContext();
+  const ref = useRef<HTMLElement>(null);
+  useMouseDrag(ref, (S, E) => {
+    const DRAG_THRESHOLD = 100;
+    const TAB_COUNT = DefaultChecklistTabsNames.length;
+    const remainOp = (a: number, b: number) => (((a % b) + b + 1) % b) - 1; // 나머지연산자. -1부터 시작하므로 +1 -1
+    setCurrentTabId(tabId => {
+      const isLeftDrag = E.x - S.x > DRAG_THRESHOLD;
+      const isRightDrag = S.x - E.x > DRAG_THRESHOLD;
+      if (isLeftDrag) return remainOp(tabId - 1, TAB_COUNT);
+      if (isRightDrag) return remainOp(tabId + 1, TAB_COUNT);
+      return tabId;
+    });
+  });
+
   return (
-    <S.Container>
+    <S.Container ref={ref}>
       {/*방 기본정보 템플릿 */}
       {currentTabId === -1 && <RoomInfoTemplate />}
       {/* 옵션 선택 템플릿 */}

--- a/frontend/src/components/EditChecklist/ChecklistContent/EditChecklistContent.tsx
+++ b/frontend/src/components/EditChecklist/ChecklistContent/EditChecklistContent.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Suspense, useRef } from 'react';
+import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import ListErrorFallback from '@/components/_common/errorBoundary/ListErrorFallback';
@@ -7,26 +7,11 @@ import { useTabContext } from '@/components/_common/Tabs/TabContext';
 import EditChecklistQuestionTemplate from '@/components/EditChecklist/ChecklistContent/EditChecklistQuestionTemplate';
 import RoomInfoTemplate from '@/components/NewChecklist/NewRoomInfoForm/RoomInfoTemplate';
 import OptionTemplate from '@/components/NewChecklist/Option/OptionTemplate';
-import { DefaultChecklistTabsNames } from '@/constants/tabs';
-import useMouseDrag from '@/hooks/useMouseDrag';
 
 const EditChecklistContent = () => {
-  const { currentTabId } = useTabContext();
+  const { currentTabId, useDragForTab } = useTabContext();
 
-  const { setCurrentTabId } = useTabContext();
-  const ref = useRef<HTMLElement>(null);
-  useMouseDrag(ref, (S, E) => {
-    const DRAG_THRESHOLD = 100;
-    const TAB_COUNT = DefaultChecklistTabsNames.length;
-    const remainOp = (a: number, b: number) => (((a % b) + b + 1) % b) - 1; // 나머지연산자. -1부터 시작하므로 +1 -1
-    setCurrentTabId(tabId => {
-      const isLeftDrag = E.x - S.x > DRAG_THRESHOLD;
-      const isRightDrag = S.x - E.x > DRAG_THRESHOLD;
-      if (isLeftDrag) return remainOp(tabId - 1, TAB_COUNT);
-      if (isRightDrag) return remainOp(tabId + 1, TAB_COUNT);
-      return tabId;
-    });
-  });
+  const ref = useDragForTab();
 
   return (
     <S.Container ref={ref}>

--- a/frontend/src/components/EditChecklist/ChecklistContent/EditChecklistQuestionTemplate.tsx
+++ b/frontend/src/components/EditChecklist/ChecklistContent/EditChecklistQuestionTemplate.tsx
@@ -4,6 +4,7 @@ import Divider from '@/components/_common/Divider/Divider';
 import Layout from '@/components/_common/layout/Layout';
 import { useTabContext } from '@/components/_common/Tabs/TabContext';
 import ChecklistQuestionItem from '@/components/NewChecklist/ChecklistQuestion/ChecklistQuestion';
+import MoveNextButton from '@/components/NewChecklist/MoveNextButton';
 import useChecklistStore from '@/store/useChecklistStore';
 import { flexColumn } from '@/styles/common';
 import theme from '@/styles/theme';
@@ -37,6 +38,8 @@ const EditChecklistQuestionTemplate = () => {
           );
         })}
       </S.ContentBox>
+
+      <MoveNextButton marginTop="2rem" marginBottom="4rem" />
     </Layout>
   );
 };

--- a/frontend/src/components/NewChecklist/ChecklistContent.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistContent.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Suspense, useRef } from 'react';
+import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import ListErrorFallback from '@/components/_common/errorBoundary/ListErrorFallback';
@@ -7,27 +7,10 @@ import { useTabContext } from '@/components/_common/Tabs/TabContext';
 import ChecklistQuestionTemplate from '@/components/NewChecklist/ChecklistQuestion/ChecklistQuestionTemplate';
 import RoomInfoTemplate from '@/components/NewChecklist/NewRoomInfoForm/RoomInfoTemplate';
 import OptionTemplate from '@/components/NewChecklist/Option/OptionTemplate';
-import { DefaultChecklistTabsNames } from '@/constants/tabs';
-import useMouseDrag from '@/hooks/useMouseDrag';
 
 const ChecklistContent = () => {
-  const { currentTabId } = useTabContext();
-
-  const { setCurrentTabId } = useTabContext();
-  const ref = useRef<HTMLElement>(null);
-
-  useMouseDrag(ref, (S, E) => {
-    const DRAG_THRESHOLD = 100;
-    const TAB_COUNT = DefaultChecklistTabsNames.length;
-    const remainOp = (a: number, b: number) => (((a % b) + b + 1) % b) - 1; // 나머지연산자. -1부터 시작하므로 +1 -1
-    setCurrentTabId(tabId => {
-      const isLeftDrag = E.x - S.x > DRAG_THRESHOLD;
-      const isRightDrag = S.x - E.x > DRAG_THRESHOLD;
-      if (isLeftDrag) return remainOp(tabId - 1, TAB_COUNT);
-      if (isRightDrag) return remainOp(tabId + 1, TAB_COUNT);
-      return tabId;
-    });
-  });
+  const { currentTabId, useDragForTab } = useTabContext();
+  useDragForTab();
 
   return (
     <S.Container>

--- a/frontend/src/components/NewChecklist/ChecklistContent.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistContent.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Suspense } from 'react';
+import { Suspense, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import ListErrorFallback from '@/components/_common/errorBoundary/ListErrorFallback';
@@ -7,9 +7,27 @@ import { useTabContext } from '@/components/_common/Tabs/TabContext';
 import ChecklistQuestionTemplate from '@/components/NewChecklist/ChecklistQuestion/ChecklistQuestionTemplate';
 import RoomInfoTemplate from '@/components/NewChecklist/NewRoomInfoForm/RoomInfoTemplate';
 import OptionTemplate from '@/components/NewChecklist/Option/OptionTemplate';
+import { DefaultChecklistTabsNames } from '@/constants/tabs';
+import useMouseDrag from '@/hooks/useMouseDrag';
 
 const ChecklistContent = () => {
   const { currentTabId } = useTabContext();
+
+  const { setCurrentTabId } = useTabContext();
+  const ref = useRef<HTMLElement>(null);
+
+  useMouseDrag(ref, (S, E) => {
+    const DRAG_THRESHOLD = 100;
+    const TAB_COUNT = DefaultChecklistTabsNames.length;
+    const remainOp = (a: number, b: number) => (((a % b) + b + 1) % b) - 1; // 나머지연산자. -1부터 시작하므로 +1 -1
+    setCurrentTabId(tabId => {
+      const isLeftDrag = E.x - S.x > DRAG_THRESHOLD;
+      const isRightDrag = S.x - E.x > DRAG_THRESHOLD;
+      if (isLeftDrag) return remainOp(tabId - 1, TAB_COUNT);
+      if (isRightDrag) return remainOp(tabId + 1, TAB_COUNT);
+      return tabId;
+    });
+  });
 
   return (
     <S.Container>

--- a/frontend/src/components/NewChecklist/ChecklistTab/NewChecklistTab.tsx
+++ b/frontend/src/components/NewChecklist/ChecklistTab/NewChecklistTab.tsx
@@ -1,11 +1,8 @@
 import { useMemo } from 'react';
 
 import ChecklistTabSuspense from '@/components/_common/errorBoundary/ChecklistTabSuspense';
-import { useTabContext } from '@/components/_common/Tabs/TabContext';
 import Tabs from '@/components/_common/Tabs/Tabs';
-import { DefaultChecklistTabsNames } from '@/constants/tabs';
 import useInitialChecklist from '@/hooks/useInitialChecklist';
-import useMouseDrag from '@/hooks/useMouseDrag';
 import useTabs from '@/hooks/useTabs';
 import useChecklistStore from '@/store/useChecklistStore';
 import isSameCategory from '@/utils/isSameCategory';
@@ -14,20 +11,6 @@ const NewChecklistTab = () => {
   const { data: checklist, isSuccess, isLoading } = useInitialChecklist();
   const checklistStore = useChecklistStore(state => state.checklistCategoryQnA);
   const { getTabsForChecklist } = useTabs();
-  const { setCurrentTabId } = useTabContext();
-
-  useMouseDrag((S, E) => {
-    const DRAG_THRESHOLD = 100;
-    const TAB_COUNT = DefaultChecklistTabsNames.length;
-    const remainOp = (a: number, b: number) => (((a % b) + b + 1) % b) - 1; // 나머지연산자. -1부터 시작하므로 +1 -1
-    setCurrentTabId(tabId => {
-      const isLeftDrag = E.x - S.x > DRAG_THRESHOLD;
-      const isRightDrag = S.x - E.x > DRAG_THRESHOLD;
-      if (isLeftDrag) return remainOp(tabId - 1, TAB_COUNT);
-      if (isRightDrag) return remainOp(tabId + 1, TAB_COUNT);
-      return tabId;
-    });
-  });
 
   const categoryTabs = useMemo(() => {
     if (isSuccess && isSameCategory(checklist, checklistStore)) {

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/DepositAndRent.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/DepositAndRent.tsx
@@ -13,6 +13,7 @@ const DepositAndRent = () => {
       <FormField.Label label="보증금 / 월세 (만원)" />
       <FormStyled.FieldBox>
         <FormField.Input
+          inputMode="decimal"
           width="medium"
           onChange={deposit.onChange}
           name="deposit"
@@ -21,6 +22,7 @@ const DepositAndRent = () => {
         />
         <FormStyled.FlexLabel label=" / " />
         <FormField.Input
+          inputMode="decimal"
           width="medium"
           placeholder=""
           onChange={rent.onChange}

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/MaintenanceFee.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/MaintenanceFee.tsx
@@ -11,6 +11,7 @@ const MaintenanceFee = () => {
       <FormField.Label label="관리비" htmlFor="maintenanceFee" />
       <FormStyled.FieldBox>
         <Input
+          inputMode="decimal"
           width="medium"
           placeholder=""
           onChange={maintenanceFee.onChange}

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/OccupancyMonth.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/OccupancyMonth.tsx
@@ -15,6 +15,7 @@ const OccupancyMonth = () => {
       <FormField.Label label="입주 가능일" htmlFor="occupancyMonth" />
       <FormStyled.FieldBox>
         <FormField.Input
+          inputMode="decimal"
           width="medium"
           onChange={occupancyMonth.onChange}
           name="occupancyMonth"

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomContractTerm.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomContractTerm.tsx
@@ -13,6 +13,7 @@ const RoomContractTerm = () => {
       <FormField.Label label="계약 기간" htmlFor="contractTerm" />
       <S.FieldBox>
         <Input
+          inputMode="decimal"
           width="medium"
           placeholder=""
           onChange={contractTerm.onChange}

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomFloor.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomFloor.tsx
@@ -26,6 +26,7 @@ const RoomFloor = () => {
           onSelectSetter={handleClickDropdown}
         />
         <Input
+          inputMode="decimal"
           width="medium"
           disabled={floorLevel.rawValue === '반지하/지하'}
           placeholder=""

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomSize.tsx
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/RoomSize.tsx
@@ -11,6 +11,7 @@ const RoomSize = () => {
       <FormField.Label label="방 크기" htmlFor="size" />
       <FormStyled.FieldBox>
         <Input
+          inputMode="decimal"
           width="medium"
           placeholder=""
           onChange={roomSize.onChange}

--- a/frontend/src/components/ResetPassword/SendVerificationEmailStep.tsx
+++ b/frontend/src/components/ResetPassword/SendVerificationEmailStep.tsx
@@ -37,9 +37,7 @@ const SendVerificationEmailStep = ({ onNext }: Props) => {
       onSuccess: () => setIsComplete(true),
       onError: error => setPostErrorMessage(error.message),
     });
-  const handleClickNext = () => {
-    onNext(email);
-  };
+  const handleClickNext = () => onNext(email);
 
   const canMove = isEmailValid && isComplete;
 
@@ -74,7 +72,7 @@ const SendVerificationEmailStep = ({ onNext }: Props) => {
                 style={{ width: '25rem' }}
               />
               <div>
-                <CS.SendButton onClick={handleClickSubmit} disabled={canMove}>
+                <CS.SendButton onClick={handleClickSubmit} disabled={canMove || !isEmailValid}>
                   전송
                 </CS.SendButton>
               </div>

--- a/frontend/src/components/_common/Tabs/TabContext.tsx
+++ b/frontend/src/components/_common/Tabs/TabContext.tsx
@@ -23,14 +23,14 @@ export const TabProvider = ({ children, defaultTab = 0 }: Props) => {
   const [currentTabId, setCurrentTabId] = useState<number>(defaultTab);
 
   // 드래그로 탭이동을 위한 훅을 리턴에 제공
-  const useDragForTab = () => {
+  const useDragForTab = (dragThreshold: number = DRAG_THRESHOLD_PIXEL) => {
     const ref = useRef<HTMLElement>(null);
     useMouseDrag(ref, (S, E) => {
       const TAB_COUNT = DefaultChecklistTabsNames.length;
 
       setCurrentTabId(tabId => {
-        const isLeftDrag = E.x - S.x > DRAG_THRESHOLD_PIXEL;
-        const isRightDrag = S.x - E.x > DRAG_THRESHOLD_PIXEL;
+        const isLeftDrag = E.x - S.x > dragThreshold;
+        const isRightDrag = S.x - E.x > dragThreshold;
         if (isLeftDrag) return remainOp(tabId - 1, TAB_COUNT);
         if (isRightDrag) return remainOp(tabId + 1, TAB_COUNT);
         return tabId;

--- a/frontend/src/components/_common/Tabs/TabContext.tsx
+++ b/frontend/src/components/_common/Tabs/TabContext.tsx
@@ -1,18 +1,16 @@
-import { createContext, ReactNode, useContext, useState } from 'react';
+import { createContext, ReactNode, RefObject, useContext, useRef, useState } from 'react';
 
 import { ERROR_MESSAGE } from '@/constants/messages/errorMessage';
+import { DefaultChecklistTabsNames, DRAG_THRESHOLD_PIXEL, remainOp } from '@/constants/tabs';
+import useMouseDrag from '@/hooks/useMouseDrag';
 
 interface ContextProps {
   currentTabId: number;
   setCurrentTabId: React.Dispatch<React.SetStateAction<number>>;
+  useDragForTab: () => RefObject<HTMLElement>;
 }
 
-const defaultContext: ContextProps = {
-  currentTabId: 0,
-  setCurrentTabId: () => {},
-};
-
-const TabContext = createContext<ContextProps>(defaultContext);
+const TabContext = createContext<ContextProps | null>(null);
 
 interface Props {
   children: ReactNode;
@@ -22,7 +20,25 @@ interface Props {
 export const TabProvider = ({ children, defaultTab = 0 }: Props) => {
   const [currentTabId, setCurrentTabId] = useState<number>(defaultTab);
 
-  return <TabContext.Provider value={{ currentTabId, setCurrentTabId }}>{children}</TabContext.Provider>;
+  // 드래그로 탭이동을 위한 훅을 리턴에 제공
+  const useDragForTab = () => {
+    const ref = useRef<HTMLElement>(null);
+    useMouseDrag(ref, (S, E) => {
+      const TAB_COUNT = DefaultChecklistTabsNames.length;
+
+      setCurrentTabId(tabId => {
+        const isLeftDrag = E.x - S.x > DRAG_THRESHOLD_PIXEL;
+        const isRightDrag = S.x - E.x > DRAG_THRESHOLD_PIXEL;
+        if (isLeftDrag) return remainOp(tabId - 1, TAB_COUNT);
+        if (isRightDrag) return remainOp(tabId + 1, TAB_COUNT);
+        return tabId;
+      });
+    });
+
+    return ref;
+  };
+
+  return <TabContext.Provider value={{ currentTabId, setCurrentTabId, useDragForTab }}>{children}</TabContext.Provider>;
 };
 
 export const useTabContext = () => {

--- a/frontend/src/components/_common/Tabs/TabContext.tsx
+++ b/frontend/src/components/_common/Tabs/TabContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, ReactNode, RefObject, useContext, useRef, useState } from 'react';
 
 import { ERROR_MESSAGE } from '@/constants/messages/errorMessage';
-import { DefaultChecklistTabsNames, DRAG_THRESHOLD_PIXEL, remainOp } from '@/constants/tabs';
+import { DefaultChecklistTabsNames, DRAG_THRESHOLD_PIXEL } from '@/constants/tabs';
 import useMouseDrag from '@/hooks/useMouseDrag';
 
 interface ContextProps {
@@ -16,6 +16,8 @@ interface Props {
   children: ReactNode;
   defaultTab: number;
 }
+
+const remainOp = (a: number, b: number) => (((a % b) + b + 1) % b) - 1; // 나머지연산자. -1부터 시작하므로 +1 -1
 
 export const TabProvider = ({ children, defaultTab = 0 }: Props) => {
   const [currentTabId, setCurrentTabId] = useState<number>(defaultTab);

--- a/frontend/src/constants/tabs.ts
+++ b/frontend/src/constants/tabs.ts
@@ -23,3 +23,6 @@ export const DefaultChecklistTabsNames: Tab[] = [
     name: '보안',
   },
 ];
+
+export const DRAG_THRESHOLD_PIXEL = 100;
+export const remainOp = (a: number, b: number) => (((a % b) + b + 1) % b) - 1; // 나머지연산자. -1부터 시작하므로 +1 -1

--- a/frontend/src/constants/tabs.ts
+++ b/frontend/src/constants/tabs.ts
@@ -25,4 +25,3 @@ export const DefaultChecklistTabsNames: Tab[] = [
 ];
 
 export const DRAG_THRESHOLD_PIXEL = 100;
-export const remainOp = (a: number, b: number) => (((a % b) + b + 1) % b) - 1; // 나머지연산자. -1부터 시작하므로 +1 -1

--- a/frontend/src/hooks/useMouseDrag.ts
+++ b/frontend/src/hooks/useMouseDrag.ts
@@ -10,12 +10,10 @@ const useMouseDrag = (ref: MutableRefObject<HTMLElement | null>, handler: Handle
   const [startPosition, setStartPosition] = useState<MousePosition | null>(null);
 
   useEffect(() => {
-    const pointerdownListener = (e: MouseEvent) => {
-      setStartPosition({ x: e.clientX, y: e.clientY });
-    };
-    const touchStartListener = (e: TouchEvent) => {
+    const pointerdownListener = (e: MouseEvent) => setStartPosition({ x: e.clientX, y: e.clientY });
+
+    const touchStartListener = (e: TouchEvent) =>
       setStartPosition({ x: e.changedTouches[0].clientX, y: e.changedTouches[0].clientX });
-    };
 
     const pointerupListener = (e: MouseEvent) => {
       const endPosition = { x: e.clientX, y: e.clientY };
@@ -30,18 +28,20 @@ const useMouseDrag = (ref: MutableRefObject<HTMLElement | null>, handler: Handle
       setStartPosition(null);
     };
 
-    ref.current?.addEventListener('mousedown', pointerdownListener);
-    ref.current?.addEventListener('touchstart', touchStartListener);
-    ref.current?.addEventListener('mouseup', pointerupListener);
-    ref.current?.addEventListener('touchend', touchEndListener);
+    const el = ref.current;
+
+    el?.addEventListener('mousedown', pointerdownListener);
+    el?.addEventListener('touchstart', touchStartListener);
+    el?.addEventListener('mouseup', pointerupListener);
+    el?.addEventListener('touchend', touchEndListener);
 
     return () => {
-      ref.current?.removeEventListener('mousedown', pointerdownListener);
-      ref.current?.removeEventListener('mouseup', pointerupListener);
-      ref.current?.removeEventListener('touchstart', touchStartListener);
-      ref.current?.removeEventListener('touchend', touchEndListener);
+      el?.removeEventListener('mousedown', pointerdownListener);
+      el?.removeEventListener('mouseup', pointerupListener);
+      el?.removeEventListener('touchstart', touchStartListener);
+      el?.removeEventListener('touchend', touchEndListener);
     };
-  }, [startPosition, handler]);
+  }, [startPosition, ref, handler]);
 };
 
 export default useMouseDrag;

--- a/frontend/src/hooks/useMouseDrag.ts
+++ b/frontend/src/hooks/useMouseDrag.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { MutableRefObject, useEffect, useState } from 'react';
 
 interface MousePosition {
   x: number;
@@ -6,7 +6,7 @@ interface MousePosition {
 }
 type Handler = (start: MousePosition, end: MousePosition) => void;
 
-const useMouseDrag = (handler: Handler) => {
+const useMouseDrag = (ref: MutableRefObject<HTMLElement | null>, handler: Handler) => {
   const [startPosition, setStartPosition] = useState<MousePosition | null>(null);
 
   useEffect(() => {
@@ -30,16 +30,16 @@ const useMouseDrag = (handler: Handler) => {
       setStartPosition(null);
     };
 
-    window.addEventListener('mousedown', pointerdownListener);
-    window.addEventListener('touchstart', touchStartListener);
-    window.addEventListener('mouseup', pointerupListener);
-    window.addEventListener('touchend', touchEndListener);
+    ref.current?.addEventListener('mousedown', pointerdownListener);
+    ref.current?.addEventListener('touchstart', touchStartListener);
+    ref.current?.addEventListener('mouseup', pointerupListener);
+    ref.current?.addEventListener('touchend', touchEndListener);
 
     return () => {
-      window.removeEventListener('mousedown', pointerdownListener);
-      window.removeEventListener('mouseup', pointerupListener);
-      window.removeEventListener('touchstart', touchStartListener);
-      window.removeEventListener('touchend', touchEndListener);
+      ref.current?.removeEventListener('mousedown', pointerdownListener);
+      ref.current?.removeEventListener('mouseup', pointerupListener);
+      ref.current?.removeEventListener('touchstart', touchStartListener);
+      ref.current?.removeEventListener('touchend', touchEndListener);
     };
   }, [startPosition, handler]);
 };


### PR DESCRIPTION
## ❗ Issue

- #956 

## ✨ 구현한 기능
- **변경내용** : 기존 = useMouseDrag가 swipe 핸들러를 window에 걸었음 -> ref를 받아서 ref에 걸도록 변경

```
- 해결하고자 한 문제 : swipe 이벤트 때문에, 주소모달에서의 스와이프에도 탭이동이 되어버림.
- 해결 :  훅의 이벤트 핸들러 범위를 전역(window)대신 좁은 범위로 잡기
```

- **변경내용** : 층수 입력 등 숫자형 방기본정보 입력시 모바일 숫자패드가 뜨도록 반영
```
- 해결하고자 한 문제 : 모바일에서 숫자패드가 뜨게 하고싶다. 그러나 type을 사용하면 stepper가 생기는 등 사이드이펙트가 존재
- 방법 : inputMode="decimal"사용
```

- **변경내용** : (UI) 편집체크리스트의 체크리스트에도 탭이동버튼을 추가
```
- 원인 : 추가/편집이 서로다른컴포넌트를 쓰고있었음. 당시에 '추가'에만 넣어줬었음.
- 방법 : 그냥 추가해줌
```

- post-signup을 fetch->fetcher로 대체하였습니다.
## 📢 논의하고 싶은 내용



## 🎸 기타

