### PR TITLE
[BE] 체크리스트 방 비교 기능을 추가 구현한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/domain/ChecklistQuestions.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/domain/ChecklistQuestions.java
@@ -15,4 +15,8 @@ public class ChecklistQuestions {
                 .filter(question -> question.matchAnswer(answer))
                 .toList();
     }
+
+    public int size() {
+        return questions.size();
+    }
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/domain/QuestionsScoreCalculator.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/domain/QuestionsScoreCalculator.java
@@ -1,0 +1,29 @@
+package com.bang_ggood.question.domain;
+
+import java.util.List;
+
+public class QuestionsScoreCalculator {
+
+    private static final int NO_QUESTIONS_ANSWERED = 0;
+    private static final int PERCENT = 100;
+
+    private final ChecklistQuestions allAnsweredQuestions;
+    private final ChecklistQuestions goodAnsweredQuestions;
+
+    public QuestionsScoreCalculator(List<ChecklistQuestion> questions) {
+        this.allAnsweredQuestions = new ChecklistQuestions(questions);
+        this.goodAnsweredQuestions = new ChecklistQuestions(allAnsweredQuestions.filterByAnswer(Answer.GOOD));
+    }
+
+    public Integer calculateScore() {
+        int allAnsweredQuestionCount = allAnsweredQuestions.size();
+        int goodAnsweredQuestionCount = goodAnsweredQuestions.size();
+
+        if (allAnsweredQuestionCount == NO_QUESTIONS_ANSWERED) {
+            return null;
+        }
+
+        double score = ((double) goodAnsweredQuestionCount / allAnsweredQuestionCount) * PERCENT;
+        return (int) Math.round(score);
+    }
+}

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/repository/ChecklistQuestionRepository.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/repository/ChecklistQuestionRepository.java
@@ -25,12 +25,12 @@ public interface ChecklistQuestionRepository extends JpaRepository<ChecklistQues
     List<Category> findAllQuestionCategoriesByUserIdAndChecklistId(@Param("userId") Long userId,
                                                                    @Param("checklistId") Long checklistId);
 
-    @Query("SELECT COUNT(cq) FROM ChecklistQuestion cq "
+    @Query("SELECT cq FROM ChecklistQuestion cq "
             + "WHERE cq.checklist.id = :checklistId "
             + "AND cq.deleted = false "
             + "AND cq.answer <> 'NONE' "
             + "AND cq.question.category.id = :categoryId")
-    Integer countAnsweredQuestionsByChecklistIdAndCategoryId(@Param("checklistId") Long checklistId,
+    List<ChecklistQuestion> findAnsweredQuestionsByChecklistIdAndCategoryId(@Param("checklistId") Long checklistId,
                                                              @Param("categoryId") Integer categoryId);
 
     @Query(" SELECT COUNT(cq) FROM ChecklistQuestion cq "

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/ChecklistQuestionService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/ChecklistQuestionService.java
@@ -8,6 +8,7 @@ import com.bang_ggood.question.domain.Category;
 import com.bang_ggood.question.domain.ChecklistQuestion;
 import com.bang_ggood.question.domain.CustomChecklistQuestion;
 import com.bang_ggood.question.domain.Question;
+import com.bang_ggood.question.domain.QuestionsScoreCalculator;
 import com.bang_ggood.question.repository.ChecklistQuestionRepository;
 import com.bang_ggood.question.repository.CustomChecklistQuestionRepository;
 import com.bang_ggood.user.domain.User;
@@ -102,22 +103,8 @@ public class ChecklistQuestionService {
     public Integer calculateCategoryScore(Long checklistId, Integer categoryId) {
         List<ChecklistQuestion> allAnsweredQuestion = checklistQuestionRepository.findAnsweredQuestionsByChecklistIdAndCategoryId(
                 checklistId, categoryId);
-
-        int allAnsweredQuestionCount = allAnsweredQuestion.size();
-        int goodAnsweredQuestionCount = countGoodAnsweredQuestion(allAnsweredQuestion);
-
-        if (allAnsweredQuestionCount == 0) {
-            return null;
-        }
-
-        double score = ((double) goodAnsweredQuestionCount / allAnsweredQuestionCount) * 100;
-        return (int) Math.round(score);
-    }
-
-    private int countGoodAnsweredQuestion(List<ChecklistQuestion> questions) {
-        return (int) questions.stream()
-                .filter(question -> question.matchAnswer(Answer.GOOD))
-                .count();
+        QuestionsScoreCalculator calculator = new QuestionsScoreCalculator(allAnsweredQuestion);
+        return calculator.calculateScore();
     }
 
     @Transactional

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/ChecklistQuestionService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/ChecklistQuestionService.java
@@ -106,7 +106,7 @@ public class ChecklistQuestionService {
                 checklistId, categoryId, Answer.GOOD);
 
         if (allAnsweredQuestionCount == 0) {
-            return 0;
+            return null;
         }
 
         double score = ((double) goodAnsweredQuestionCount / allAnsweredQuestionCount) * 100;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/ChecklistQuestionService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/ChecklistQuestionService.java
@@ -100,10 +100,11 @@ public class ChecklistQuestionService {
 
     @Transactional(readOnly = true)
     public Integer calculateCategoryScore(Long checklistId, Integer categoryId) {
-        int allAnsweredQuestionCount = checklistQuestionRepository.countAnsweredQuestionsByChecklistIdAndCategoryId(
+        List<ChecklistQuestion> allAnsweredQuestion = checklistQuestionRepository.findAnsweredQuestionsByChecklistIdAndCategoryId(
                 checklistId, categoryId);
-        int goodAnsweredQuestionCount = checklistQuestionRepository.countAnsweredQuestionsByChecklistIdAndCategoryIdAndAnswer(
-                checklistId, categoryId, Answer.GOOD);
+
+        int allAnsweredQuestionCount = allAnsweredQuestion.size();
+        int goodAnsweredQuestionCount = countGoodAnsweredQuestion(allAnsweredQuestion);
 
         if (allAnsweredQuestionCount == 0) {
             return null;
@@ -111,6 +112,12 @@ public class ChecklistQuestionService {
 
         double score = ((double) goodAnsweredQuestionCount / allAnsweredQuestionCount) * 100;
         return (int) Math.round(score);
+    }
+
+    private int countGoodAnsweredQuestion(List<ChecklistQuestion> questions) {
+        return (int) questions.stream()
+                .filter(question -> question.matchAnswer(Answer.GOOD))
+                .count();
     }
 
     @Transactional

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/domain/QuestionsScoreCalculatorTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/domain/QuestionsScoreCalculatorTest.java
@@ -1,0 +1,103 @@
+package com.bang_ggood.question.domain;
+
+import com.bang_ggood.IntegrationTestSupport;
+import com.bang_ggood.checklist.ChecklistFixture;
+import com.bang_ggood.checklist.domain.Checklist;
+import com.bang_ggood.checklist.repository.ChecklistRepository;
+import com.bang_ggood.question.ChecklistQuestionFixture;
+import com.bang_ggood.question.QuestionFixture;
+import com.bang_ggood.room.RoomFixture;
+import com.bang_ggood.room.domain.Room;
+import com.bang_ggood.room.repository.RoomRepository;
+import com.bang_ggood.user.UserFixture;
+import com.bang_ggood.user.domain.User;
+import com.bang_ggood.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QuestionsScoreCalculatorTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ChecklistRepository checklistRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Checklist checklist;
+
+    @BeforeEach
+    void beforeEach() {
+        User user = userRepository.save(UserFixture.USER1());
+        Room room = roomRepository.save(RoomFixture.ROOM_1());
+        checklist = checklistRepository.save(ChecklistFixture.CHECKLIST1_USER1(room, user));
+    }
+
+    @DisplayName("점수 계산 성공 : 모두 GOOD일 경우")
+    @Test
+    void calculateCategoryScore() {
+        // given
+        List<ChecklistQuestion> checklistQuestions = List.of(
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION2_GOOD(checklist, QuestionFixture.QUESTION1_CATEGORY1)
+        );
+
+        // when
+        QuestionsScoreCalculator calculator = new QuestionsScoreCalculator(checklistQuestions);
+
+        // then
+        assertThat(calculator.calculateScore()).isEqualTo(100);
+    }
+
+    @DisplayName("점수 계산 성공 : 일부 답변만 GOOD인 경우")
+    @Test
+    void calculateCategoryScore_partialGoodAnswers() {
+        // given
+        List<ChecklistQuestion> checklistQuestions = List.of(
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION1_BAD(checklist, QuestionFixture.QUESTION1_CATEGORY1),
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION2_GOOD(checklist, QuestionFixture.QUESTION2_CATEGORY1)
+        );
+
+        // when
+        QuestionsScoreCalculator calculator = new QuestionsScoreCalculator(checklistQuestions);
+
+        // then
+        assertThat(calculator.calculateScore()).isEqualTo(50);
+    }
+
+    @DisplayName("점수 계산 성공 : 모든 답변이 BAD인 경우")
+    @Test
+    void calculateCategoryScore_allBadAnswers() {
+        // given
+        List<ChecklistQuestion> checklistQuestions = List.of(
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION1_BAD(checklist, QuestionFixture.QUESTION1_CATEGORY1)
+        );
+
+        // when
+        QuestionsScoreCalculator calculator = new QuestionsScoreCalculator(checklistQuestions);
+
+        // then
+        assertThat(calculator.calculateScore()).isEqualTo(0);
+    }
+
+    @DisplayName("점수 계산 성공 : 답변이 없는 경우")
+    @Test
+    void calculateCategoryScore_noAnswers() {
+        // given & when
+        List<ChecklistQuestion> checklistQuestions = new ArrayList<>();
+
+        // when
+        QuestionsScoreCalculator calculator = new QuestionsScoreCalculator(checklistQuestions);
+
+        // then
+        assertThat(calculator.calculateScore()).isEqualTo(null);
+    }
+
+}

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/ChecklistQuestionRepositoryTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/ChecklistQuestionRepositoryTest.java
@@ -85,7 +85,7 @@ class ChecklistQuestionRepositoryTest extends IntegrationTestSupport {
         assertThat(categories).hasSize(2);
     }
 
-    @DisplayName("주어진 체크리스트 ID와 카테고리 ID로 답변된 질문 수 카운트 성공")
+    @DisplayName("주어진 체크리스트 ID와 카테고리 ID로 답변된 질문 조회 성공")
     @Test
     void countAnsweredQuestionsByChecklistIdAndCategoryId() {
         // given
@@ -98,12 +98,13 @@ class ChecklistQuestionRepositoryTest extends IntegrationTestSupport {
 
         // when
         Integer categoryId = cq1.getQuestion().getCategory().getId();
-        Integer count = checklistQuestionRepository.countAnsweredQuestionsByChecklistIdAndCategoryId(checklist.getId(),
-                categoryId);
+        List<ChecklistQuestion> answeredQuestions = checklistQuestionRepository.findAnsweredQuestionsByChecklistIdAndCategoryId(
+                checklist.getId(), categoryId);
 
         // then
-        assertThat(count).isEqualTo(2);
+        assertThat(answeredQuestions.size()).isEqualTo(2);
     }
+
 
     @DisplayName("주어진 체크리스트 ID, 카테고리 ID, 특정 답변으로 질문 수 카운트 성공")
     @Test

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/service/ChecklistQuestionServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/service/ChecklistQuestionServiceTest.java
@@ -210,24 +210,7 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
         assertThat(categories).hasSize(1);
     }
 
-    @DisplayName("카테고리 점수 계산 성공 : 모두 GOOD일 경우")
-    @Test
-    void calculateCategoryScore() {
-        // given
-        List<ChecklistQuestion> checklistQuestions = List.of(
-                ChecklistQuestionFixture.CHECKLIST1_QUESTION2_GOOD(checklist, QuestionFixture.QUESTION1_CATEGORY1)
-        );
-        checklistQuestionService.createQuestions(checklistQuestions);
-
-        // when
-        Integer categoryId = QuestionFixture.QUESTION1_CATEGORY1.getCategory().getId();
-        Integer score = checklistQuestionService.calculateCategoryScore(checklist.getId(), categoryId);
-
-        // then
-        assertThat(score).isEqualTo(100);
-    }
-
-    @DisplayName("카테고리 점수 계산 성공 : 일부 답변만 GOOD인 경우")
+    @DisplayName("카테고리 점수 계산 성공")
     @Test
     void calculateCategoryScore_partialGoodAnswers() {
         // given
@@ -243,34 +226,6 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(score).isEqualTo(50);
-    }
-
-    @DisplayName("카테고리 점수 계산 성공 : 모든 답변이 BAD인 경우")
-    @Test
-    void calculateCategoryScore_allBadAnswers() {
-        // given
-        List<ChecklistQuestion> checklistQuestions = List.of(
-                ChecklistQuestionFixture.CHECKLIST1_QUESTION1_BAD(checklist, QuestionFixture.QUESTION1_CATEGORY1)
-        );
-        checklistQuestionService.createQuestions(checklistQuestions);
-
-        // when
-        Integer categoryId = QuestionFixture.QUESTION1_CATEGORY1.getCategory().getId();
-        Integer score = checklistQuestionService.calculateCategoryScore(checklist.getId(), categoryId);
-
-        // then
-        assertThat(score).isEqualTo(0);
-    }
-
-    @DisplayName("카테고리 점수 계산 성공 : 답변이 없는 경우")
-    @Test
-    void calculateCategoryScore_noAnswers() {
-        // given & when
-        Integer categoryId = QuestionFixture.QUESTION1_CATEGORY1.getCategory().getId();
-        Integer score = checklistQuestionService.calculateCategoryScore(checklist.getId(), categoryId);
-
-        // then
-        assertThat(score).isEqualTo(null);
     }
 
 

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/service/ChecklistQuestionServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/service/ChecklistQuestionServiceTest.java
@@ -227,17 +227,6 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
         assertThat(score).isEqualTo(100);
     }
 
-    @DisplayName("카테고리 점수 계산 성공 : 답변이 없는 경우")
-    @Test
-    void calculateCategoryScore_noAnswers() {
-        // given & when
-        Integer categoryId = QuestionFixture.QUESTION1_CATEGORY1.getCategory().getId();
-        Integer score = checklistQuestionService.calculateCategoryScore(checklist.getId(), categoryId);
-
-        // then
-        assertThat(score).isEqualTo(0);
-    }
-
     @DisplayName("카테고리 점수 계산 성공 : 일부 답변만 GOOD인 경우")
     @Test
     void calculateCategoryScore_partialGoodAnswers() {
@@ -254,6 +243,34 @@ class ChecklistQuestionServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(score).isEqualTo(50);
+    }
+
+    @DisplayName("카테고리 점수 계산 성공 : 모든 답변이 BAD인 경우")
+    @Test
+    void calculateCategoryScore_allBadAnswers() {
+        // given
+        List<ChecklistQuestion> checklistQuestions = List.of(
+                ChecklistQuestionFixture.CHECKLIST1_QUESTION1_BAD(checklist, QuestionFixture.QUESTION1_CATEGORY1)
+        );
+        checklistQuestionService.createQuestions(checklistQuestions);
+
+        // when
+        Integer categoryId = QuestionFixture.QUESTION1_CATEGORY1.getCategory().getId();
+        Integer score = checklistQuestionService.calculateCategoryScore(checklist.getId(), categoryId);
+
+        // then
+        assertThat(score).isEqualTo(0);
+    }
+
+    @DisplayName("카테고리 점수 계산 성공 : 답변이 없는 경우")
+    @Test
+    void calculateCategoryScore_noAnswers() {
+        // given & when
+        Integer categoryId = QuestionFixture.QUESTION1_CATEGORY1.getCategory().getId();
+        Integer score = checklistQuestionService.calculateCategoryScore(checklist.getId(), categoryId);
+
+        // then
+        assertThat(score).isEqualTo(null);
     }
 
 


### PR DESCRIPTION
## ❗ Issue
- #974 

## ✨ 구현한 기능
`AnsweredQuestions을 먼저 가져오고 Answer.GOOD인 것만 필터링해서 갯수를 확인하면 2번 데이터베이스에 요청을 보내지 않아도 될 것 같아요!
`

불필요한 데이터를 필터링을 위해 다 메모리에 얹고 필터링하는 리소스와 2번 요청을 보내는 리소스 중 어느 것이 더 클까 고민하다가 후자를 택했었는데요! (실제로 테스트 해 보니 거의 차이가 없기도 하였습니다)

하지만 PROD 환경에서는 DB IO를 줄이는 게 베스트인 것 같아 제제의 의견을 반영해 볼게욥 👍

---

```
비교를 위한 계산 로직이 꽤 중요한 도메인이라고 생각하는데 도메인 내부에서 처리하는 건 어떤가요? 🤔
계산 로직을 가진 도메인이 있다면 해당 테스트도 도메인 테스트로 변경할 수 있을 것 같아요~
```

반영하였습니다!

---

체크 된 질문이 없을 때에 null을 반환하는 것도 추가 구현하였습니다!


## 📢 논의하고 싶은 내용



## 🎸 기타

