### PR TITLE
[BE] 로그레벨별로 파일 분리

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -77,7 +77,7 @@ jobs:
         run: sudo fuser -k -n tcp 8080 || true
         
       - name: Start server
-        run: sudo nohup java -jar -Dspring.profiles.active=dev -Duser.timezone=Asia/Seoul ./backend/bang-ggood/build/libs/*SNAPSHOT.jar > /home/ubuntu/actions-runner/server.log 2>&1 &
+        run: sudo nohup java -jar -Dspring.profiles.active=dev -Duser.timezone=Asia/Seoul ./backend/bang-ggood/build/libs/*SNAPSHOT.jar &
 
       - name: Delete unhealth_flag file
         run: sudo rm /etc/nginx/sites-available/unhealth_flag.txt

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -70,7 +70,7 @@ jobs:
         run: sudo fuser -k -n tcp 8080 || true
 
       - name: Start server
-        run: sudo nohup java -jar -Dspring.profiles.active=prod -Duser.timezone=Asia/Seoul ./backend/bang-ggood/build/libs/*SNAPSHOT.jar > /home/ubuntu/actions-runner/server.log 2>&1 &
+        run: sudo nohup java -jar -Dspring.profiles.active=prod -Duser.timezone=Asia/Seoul ./backend/bang-ggood/build/libs/*SNAPSHOT.jar &
 
   deploy2:
     needs: deploy1

--- a/backend/bang-ggood/src/main/resources/logback.xml
+++ b/backend/bang-ggood/src/main/resources/logback.xml
@@ -3,7 +3,10 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <appender name="INFO" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/info-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>
             <onMatch>ACCEPT</onMatch>
@@ -14,7 +17,10 @@
         </encoder>
     </appender>
 
-    <appender name="WARN" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/warn-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>
             <onMatch>ACCEPT</onMatch>
@@ -25,7 +31,10 @@
         </encoder>
     </appender>
 
-    <appender name="ERROR" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/error-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
             <onMatch>ACCEPT</onMatch>


### PR DESCRIPTION
## ❗ Issue

- #1006 

## ✨ 구현한 기능

- 기존에 하나의 파일로 생성하던 로그를 레벨별로 분리
  - 파일명 패턴 예시 : `/home/ubuntu/logs/warn-%d{yyyy-MM-dd}.log`

## 📢 논의하고 싶은 내용

## 🎸 기타

