### PR TITLE
[BE] 로그레벨별로 파일 분리

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -77,7 +77,7 @@ jobs:
         run: sudo fuser -k -n tcp 8080 || true
         
       - name: Start server
-        run: sudo nohup java -jar -Dspring.profiles.active=dev -Duser.timezone=Asia/Seoul ./backend/bang-ggood/build/libs/*SNAPSHOT.jar > /home/ubuntu/actions-runner/server.log 2>&1 &
+        run: sudo nohup java -jar -Dspring.profiles.active=dev -Duser.timezone=Asia/Seoul ./backend/bang-ggood/build/libs/*SNAPSHOT.jar &
 
       - name: Delete unhealth_flag file
         run: sudo rm /etc/nginx/sites-available/unhealth_flag.txt

--- a/backend/bang-ggood/src/main/resources/console-error-appender.xml
+++ b/backend/bang-ggood/src/main/resources/console-error-appender.xml
@@ -1,0 +1,12 @@
+<included>
+    <appender name="CONSOLE_ERROR" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){RED} [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/backend/bang-ggood/src/main/resources/console-info-appender.xml
+++ b/backend/bang-ggood/src/main/resources/console-info-appender.xml
@@ -1,0 +1,12 @@
+<included>
+    <appender name="CONSOLE_INFO" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){BLUE} [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/backend/bang-ggood/src/main/resources/console-warn-appender.xml
+++ b/backend/bang-ggood/src/main/resources/console-warn-appender.xml
@@ -1,0 +1,12 @@
+<included>
+    <appender name="CONSOLE_WARN" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){YELLOW} [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/backend/bang-ggood/src/main/resources/file-error-appender.xml
+++ b/backend/bang-ggood/src/main/resources/file-error-appender.xml
@@ -2,6 +2,7 @@
     <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>/home/ubuntu/logs/error-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>3</maxHistory> <!-- 3일 후 삭제 -->
         </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>

--- a/backend/bang-ggood/src/main/resources/file-error-appender.xml
+++ b/backend/bang-ggood/src/main/resources/file-error-appender.xml
@@ -1,0 +1,15 @@
+<included>
+    <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/error-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){RED} [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/backend/bang-ggood/src/main/resources/file-info-appender.xml
+++ b/backend/bang-ggood/src/main/resources/file-info-appender.xml
@@ -1,0 +1,15 @@
+<included>
+    <appender name="FILE_INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/info-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){BLUE} [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/backend/bang-ggood/src/main/resources/file-warn-appender.xml
+++ b/backend/bang-ggood/src/main/resources/file-warn-appender.xml
@@ -2,6 +2,7 @@
     <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>/home/ubuntu/logs/warn-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>3</maxHistory> <!-- 3일 후 삭제 -->
         </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>

--- a/backend/bang-ggood/src/main/resources/file-warn-appender.xml
+++ b/backend/bang-ggood/src/main/resources/file-warn-appender.xml
@@ -1,0 +1,15 @@
+<included>
+    <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/warn-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){YELLOW} [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/backend/bang-ggood/src/main/resources/logback.xml
+++ b/backend/bang-ggood/src/main/resources/logback.xml
@@ -3,51 +3,38 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <appender name="INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/home/ubuntu/logs/info-%d{yyyy-MM-dd}.log</fileNamePattern>
-        </rollingPolicy>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>INFO</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){BLUE} [%thread] %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <springProfile name="prod">
+        <include resource="file-info-appender.xml"/>
+        <include resource="file-warn-appender.xml"/>
+        <include resource="file-error-appender.xml"/>
 
-    <appender name="WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/home/ubuntu/logs/warn-%d{yyyy-MM-dd}.log</fileNamePattern>
-        </rollingPolicy>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>WARN</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){YELLOW} [%thread] %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
+        <root level="INFO">
+            <appender-ref ref="FILE_INFO"/>
+            <appender-ref ref="FILE_WARN"/>
+            <appender-ref ref="FILE_ERROR"/>
+        </root>
+    </springProfile>
 
-    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>/home/ubuntu/logs/error-%d{yyyy-MM-dd}.log</fileNamePattern>
-        </rollingPolicy>
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>ERROR</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level){RED} [%thread] %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
+    <springProfile name="dev">
+        <include resource="file-info-appender.xml"/>
+        <include resource="file-warn-appender.xml"/>
+        <include resource="file-error-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="FILE_INFO"/>
+            <appender-ref ref="FILE_WARN"/>
+            <appender-ref ref="FILE_ERROR"/>
+        </root>
+    </springProfile>
+
+    <!--LOCAL & DEV-->
+    <include resource="console-info-appender.xml"/>
+    <include resource="console-warn-appender.xml"/>
+    <include resource="console-error-appender.xml"/>
 
     <root level="INFO">
-        <appender-ref ref="INFO"/>
-        <appender-ref ref="WARN"/>
-        <appender-ref ref="ERROR"/>
+        <appender-ref ref="CONSOLE_INFO"/>
+        <appender-ref ref="CONSOLE_WARN"/>
+        <appender-ref ref="CONSOLE_ERROR"/>
     </root>
 </configuration>

--- a/backend/bang-ggood/src/main/resources/logback.xml
+++ b/backend/bang-ggood/src/main/resources/logback.xml
@@ -3,7 +3,10 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <appender name="INFO" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/info-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>
             <onMatch>ACCEPT</onMatch>
@@ -14,7 +17,10 @@
         </encoder>
     </appender>
 
-    <appender name="WARN" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/warn-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>
             <onMatch>ACCEPT</onMatch>
@@ -25,7 +31,10 @@
         </encoder>
     </appender>
 
-    <appender name="ERROR" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/home/ubuntu/logs/error-%d{yyyy-MM-dd}.log</fileNamePattern>
+        </rollingPolicy>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
             <onMatch>ACCEPT</onMatch>


### PR DESCRIPTION
## ❗ Issue

- #1006 

## ✨ 구현한 기능

- 기존에 하나의 파일로 생성하던 로그를 레벨별로 분리
  - 파일명 패턴 예시 : /home/ubuntu/logs/warn-%d{yyyy-MM-dd}.log

## 📢 논의하고 싶은 내용



## 🎸 기타

