### PR TITLE
[FE] 어드민/유저/게스트 구별 로직을 추가하여 유저스토어를 제작한다.

### DIFF
--- a/frontend/src/components/ArticleDetail/ArticleContent.tsx
+++ b/frontend/src/components/ArticleDetail/ArticleContent.tsx
@@ -32,6 +32,9 @@ const ArticleContent = () => {
         <MarkdownPreview
           source={article?.content}
           style={{ padding: 10 }}
+          wrapperElement={{
+            'data-color-mode': 'light',
+          }}
           rehypeRewrite={(node, index, parent) => {
             if (
               node.type === 'element' &&

--- a/frontend/src/components/MyPage/UserFeature.tsx
+++ b/frontend/src/components/MyPage/UserFeature.tsx
@@ -8,12 +8,12 @@ import LogoutModal from '@/components/MyPage/LogoutModal';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { ROUTE_PATH } from '@/constants/routePath';
 import { VOC_URL } from '@/constants/VoC';
+import useUserQuery from '@/hooks/query/useUserQuery';
 import useModal from '@/hooks/useModal';
-import useUserStore from '@/store/useUserStore';
 import { boxShadowSpread, flexColumn, flexRow, flexSpaceBetween, title4 } from '@/styles/common';
 
 const UserFeature = () => {
-  const { user } = useUserStore();
+  const { data: user } = useUserQuery();
 
   const navigate = useNavigate();
 
@@ -42,7 +42,7 @@ const UserFeature = () => {
           </>
         </S.LabelContainer>
 
-        {user.userType !== 'ADMIN' && (
+        {user?.userType !== 'ADMIN' && (
           <S.Section>
             <S.LabelContainer>방끗이 도움되었나요? 한마디 남겨주세요!</S.LabelContainer>
             <S.Button tabIndex={1} onClick={handleMoveVoc}>
@@ -52,7 +52,7 @@ const UserFeature = () => {
           </S.Section>
         )}
 
-        {user.userType === 'ADMIN' && (
+        {user?.userType === 'ADMIN' && (
           <S.Section>
             <S.Button tabIndex={1} onClick={() => navigate(ROUTE_PATH.admin)}>
               어드민 페이지 바로가기

--- a/frontend/src/components/MyPage/UserFeature.tsx
+++ b/frontend/src/components/MyPage/UserFeature.tsx
@@ -1,20 +1,23 @@
 import styled from '@emotion/styled';
 import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 import { ArrowRightCircle } from '@/assets/assets';
 import DeleteAccountModal from '@/components/MyPage/DeleteAccountModal';
 import LogoutModal from '@/components/MyPage/LogoutModal';
 import { QUERY_KEYS } from '@/constants/queryKeys';
+import { ROUTE_PATH } from '@/constants/routePath';
 import { VOC_URL } from '@/constants/VoC';
-import useUserQuery from '@/hooks/query/useUserQuery';
 import useModal from '@/hooks/useModal';
+import useUserStore from '@/store/useUserStore';
 import { boxShadowSpread, flexColumn, flexRow, flexSpaceBetween, title4 } from '@/styles/common';
 
 const UserFeature = () => {
-  useUserQuery();
+  const { user } = useUserStore();
+
+  const navigate = useNavigate();
 
   const queryClient = useQueryClient();
-
   const checklist = queryClient.getQueryData([QUERY_KEYS.CHECKLIST_LIST]);
 
   const { isModalOpen: isLogoutModalOpen, openModal: openLogoutModal, closeModal: closeLogoutModal } = useModal();
@@ -39,13 +42,24 @@ const UserFeature = () => {
           </>
         </S.LabelContainer>
 
-        <S.Section>
-          <S.LabelContainer>방끗이 도움되었나요? 한마디 남겨주세요!</S.LabelContainer>
-          <S.Button tabIndex={1} onClick={handleMoveVoc}>
-            방끗이 기다려요, 의견 남기기!
-            <ArrowRightCircle aria-hidden="true" />
-          </S.Button>
-        </S.Section>
+        {user.userType !== 'ADMIN' && (
+          <S.Section>
+            <S.LabelContainer>방끗이 도움되었나요? 한마디 남겨주세요!</S.LabelContainer>
+            <S.Button tabIndex={1} onClick={handleMoveVoc}>
+              방끗이 기다려요, 의견 남기기!
+              <ArrowRightCircle aria-hidden="true" />
+            </S.Button>
+          </S.Section>
+        )}
+
+        {user.userType === 'ADMIN' && (
+          <S.Section>
+            <S.Button tabIndex={1} onClick={() => navigate(ROUTE_PATH.admin)}>
+              어드민 페이지 바로가기
+              <ArrowRightCircle aria-hidden="true" />
+            </S.Button>
+          </S.Section>
+        )}
 
         <S.Section>
           <S.LabelContainer>방끗 잠시 안녕!</S.LabelContainer>

--- a/frontend/src/components/_common/LoginButton/EmailLoginButton.tsx
+++ b/frontend/src/components/_common/LoginButton/EmailLoginButton.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/_common/Button/Button';
 import { ROUTE_PATH } from '@/constants/routePath';
-import { trackBasicLoginButton } from '@/service/amplitude/trackEvent';
+import { trackEmailLoginButton } from '@/service/amplitude/trackEvent';
 
 const EmailLoginButton = () => {
   const navigate = useNavigate();
@@ -15,7 +15,7 @@ const EmailLoginButton = () => {
       isSquare
       onClick={() => {
         navigate(ROUTE_PATH.signIn);
-        trackBasicLoginButton();
+        trackEmailLoginButton();
       }}
     />
   );

--- a/frontend/src/constants/messages/apiErrorMessage.ts
+++ b/frontend/src/constants/messages/apiErrorMessage.ts
@@ -12,7 +12,7 @@ export const API_ERROR_MESSAGE = {
   USER_EMAIL_ALREADY_USED: '해당 이메일은 이미 사용 중이에요.',
   USER_INVALID_FORMAT: '이메일 또는 비밀번호 형식이 올바르지 않아요.',
   // TODO: 백엔드 변경 요쳥 필요
-  INVALID_PARAMETER: '이메일이 정상적으로 입력되지 않았어요. \n다시 시도해 주세요.',
+  INVALID_PARAMETER: '서버 문제가 발생했어요. \n다시 시도해 주세요.',
   BAD_REQUEST: '비밀번호가 입력되지 않았어요. \n다시 시도해 주세요.',
 
   // 방 정보 요청 형식 에러

--- a/frontend/src/hooks/query/useAddOAuthUserQuery.ts
+++ b/frontend/src/hooks/query/useAddOAuthUserQuery.ts
@@ -1,7 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { postOAuthLogin } from '@/apis/user';
+import { getUserInfo, postOAuthLogin } from '@/apis/user';
 import { QUERY_KEYS } from '@/constants/queryKeys';
+import useToast from '@/hooks/useToast';
+import amplitudeInitializer from '@/service/amplitude/amplitudeInitializer';
+import useUserStore from '@/store/useUserStore';
 
 interface MutationVariables {
   code: string;
@@ -10,10 +13,24 @@ interface MutationVariables {
 
 const useAddOAuthUserQuery = () => {
   const queryClient = useQueryClient();
+  const { user, setUser } = useUserStore();
+  const { init } = amplitudeInitializer();
+  const { showToast } = useToast();
+
   return useMutation({
     mutationFn: ({ code, redirectUri }: MutationVariables) => postOAuthLogin(code, redirectUri),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.AUTH] });
+
+      const initAmplitudeUser = async () => {
+        const result = await getUserInfo();
+        setUser(result);
+
+        init(user.userEmail);
+        showToast({ message: `${user?.userName}님, 환영합니다.`, type: 'confirm' });
+      };
+
+      initAmplitudeUser();
     },
   });
 };

--- a/frontend/src/hooks/query/useAddOAuthUserQuery.ts
+++ b/frontend/src/hooks/query/useAddOAuthUserQuery.ts
@@ -22,7 +22,7 @@ const useAddOAuthUserQuery = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.AUTH] });
 
-      const initAmplitudeUser = async () => {
+      const initUser = async () => {
         const result = await getUserInfo();
         setUser(result);
 
@@ -30,7 +30,7 @@ const useAddOAuthUserQuery = () => {
         showToast({ message: `${user?.userName}님, 환영합니다.`, type: 'confirm' });
       };
 
-      initAmplitudeUser();
+      initUser();
     },
   });
 };

--- a/frontend/src/hooks/query/useDeleteAccount.ts
+++ b/frontend/src/hooks/query/useDeleteAccount.ts
@@ -3,18 +3,15 @@ import { useNavigate } from 'react-router-dom';
 
 import { deleteAccount } from '@/apis/user';
 import { ROUTE_PATH } from '@/constants/routePath';
-import useUserStore from '@/store/useUserStore';
 
 const useDeleteAccount = () => {
   const queryClient = useQueryClient();
-  const { reset } = useUserStore();
   const navigate = useNavigate();
 
   return useMutation({
     mutationFn: deleteAccount,
     onSuccess: () => {
       queryClient.clear();
-      reset();
       navigate(ROUTE_PATH.root);
     },
   });

--- a/frontend/src/hooks/query/useDeleteAccount.ts
+++ b/frontend/src/hooks/query/useDeleteAccount.ts
@@ -3,15 +3,18 @@ import { useNavigate } from 'react-router-dom';
 
 import { deleteAccount } from '@/apis/user';
 import { ROUTE_PATH } from '@/constants/routePath';
+import useUserStore from '@/store/useUserStore';
 
 const useDeleteAccount = () => {
   const queryClient = useQueryClient();
+  const { reset } = useUserStore();
   const navigate = useNavigate();
 
   return useMutation({
     mutationFn: deleteAccount,
     onSuccess: () => {
       queryClient.clear();
+      reset();
       navigate(ROUTE_PATH.root);
     },
   });

--- a/frontend/src/hooks/query/useLogoutQuery.ts
+++ b/frontend/src/hooks/query/useLogoutQuery.ts
@@ -4,16 +4,19 @@ import { useNavigate } from 'react-router-dom';
 import { postLogout } from '@/apis/user';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { ROUTE_PATH } from '@/constants/routePath';
+import useUserStore from '@/store/useUserStore';
 
 const useLogoutQuery = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { reset } = useUserStore();
 
   return useMutation({
     mutationFn: postLogout,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.AUTH] });
       queryClient.clear();
+      reset();
       navigate(ROUTE_PATH.root);
     },
   });

--- a/frontend/src/hooks/query/usePostSignInQuery.ts
+++ b/frontend/src/hooks/query/usePostSignInQuery.ts
@@ -20,7 +20,7 @@ const usePostSignInQuery = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.AUTH] });
 
-      const initAmplitudeUser = async () => {
+      const initUser = async () => {
         const result = await getUserInfo();
         setUser(result);
 
@@ -28,8 +28,7 @@ const usePostSignInQuery = () => {
         showToast({ message: `${user?.userName}님, 환영합니다.`, type: 'confirm' });
       };
 
-      initAmplitudeUser();
-
+      initUser();
       navigate(ROUTE_PATH.home);
     },
   });

--- a/frontend/src/hooks/query/usePostSignInQuery.ts
+++ b/frontend/src/hooks/query/usePostSignInQuery.ts
@@ -6,12 +6,10 @@ import { QUERY_KEYS } from '@/constants/queryKeys';
 import { ROUTE_PATH } from '@/constants/routePath';
 import useToast from '@/hooks/useToast';
 import amplitudeInitializer from '@/service/amplitude/amplitudeInitializer';
-import useUserStore from '@/store/useUserStore';
 
 const usePostSignInQuery = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { user, setUser } = useUserStore();
   const { init } = amplitudeInitializer();
   const { showToast } = useToast();
 
@@ -21,8 +19,12 @@ const usePostSignInQuery = () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.AUTH] });
 
       const initUser = async () => {
-        const result = await getUserInfo();
-        setUser(result);
+        // 유저 정보 가져오기
+        const user = await queryClient.fetchQuery({
+          queryKey: [QUERY_KEYS.USER],
+          queryFn: getUserInfo,
+        });
+        queryClient.setQueryData([QUERY_KEYS.USER], user);
 
         init(user.userEmail);
         showToast({ message: `${user?.userName}님, 환영합니다.`, type: 'confirm' });

--- a/frontend/src/hooks/query/usePostSignInQuery.ts
+++ b/frontend/src/hooks/query/usePostSignInQuery.ts
@@ -1,17 +1,35 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
-import { postSignIn } from '@/apis/user';
+import { getUserInfo, postSignIn } from '@/apis/user';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { ROUTE_PATH } from '@/constants/routePath';
+import useToast from '@/hooks/useToast';
+import amplitudeInitializer from '@/service/amplitude/amplitudeInitializer';
+import useUserStore from '@/store/useUserStore';
 
 const usePostSignInQuery = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { user, setUser } = useUserStore();
+  const { init } = amplitudeInitializer();
+  const { showToast } = useToast();
+
   return useMutation({
     mutationFn: postSignIn,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.AUTH] });
+
+      const initAmplitudeUser = async () => {
+        const result = await getUserInfo();
+        setUser(result);
+
+        init(user.userEmail);
+        showToast({ message: `${user?.userName}님, 환영합니다.`, type: 'confirm' });
+      };
+
+      initAmplitudeUser();
+
       navigate(ROUTE_PATH.home);
     },
   });

--- a/frontend/src/hooks/query/useUserQuery.ts
+++ b/frontend/src/hooks/query/useUserQuery.ts
@@ -3,12 +3,9 @@ import { useEffect } from 'react';
 
 import { getUserInfo } from '@/apis/user';
 import { QUERY_KEYS } from '@/constants/queryKeys';
-import useUserStore from '@/store/useUserStore';
 import { User } from '@/types/user';
 
 const useUserQuery = () => {
-  const { setUser } = useUserStore();
-
   const userQuery = useQuery<User>({
     queryKey: [QUERY_KEYS.AUTH, QUERY_KEYS.USER],
     queryFn: getUserInfo,
@@ -17,9 +14,8 @@ const useUserQuery = () => {
 
   useEffect(() => {
     if (userQuery.isSuccess && userQuery.data) {
-      setUser(userQuery.data);
     }
-  }, [userQuery.isSuccess, userQuery.data, setUser]);
+  }, [userQuery.isSuccess, userQuery.data]);
 
   return userQuery;
 };

--- a/frontend/src/hooks/query/useUserQuery.ts
+++ b/frontend/src/hooks/query/useUserQuery.ts
@@ -1,15 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
 import { getUserInfo } from '@/apis/user';
 import { QUERY_KEYS } from '@/constants/queryKeys';
+import useUserStore from '@/store/useUserStore';
 import { User } from '@/types/user';
 
 const useUserQuery = () => {
-  return useQuery<User>({
+  const { setUser } = useUserStore();
+
+  const userQuery = useQuery<User>({
     queryKey: [QUERY_KEYS.AUTH, QUERY_KEYS.USER],
     queryFn: getUserInfo,
     retry: false,
   });
+
+  useEffect(() => {
+    if (userQuery.isSuccess && userQuery.data) {
+      setUser(userQuery.data);
+    }
+  }, [userQuery.isSuccess, userQuery.data, setUser]);
+
+  return userQuery;
 };
 
 export default useUserQuery;

--- a/frontend/src/hooks/useAutoLogin.ts
+++ b/frontend/src/hooks/useAutoLogin.ts
@@ -1,17 +1,11 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { deleteToken, getIsUserValid, getUserInfo, postReissueAccessToken } from '@/apis/user';
+import { deleteToken, getIsUserValid, postReissueAccessToken } from '@/apis/user';
 import { ROUTE_PATH } from '@/constants/routePath';
-import useToast from '@/hooks/useToast';
-import amplitudeInitializer from '@/service/amplitude/amplitudeInitializer';
-import useUserStore from '@/store/useUserStore';
 
 const useAutoLogin = () => {
   const navigate = useNavigate();
-  const { showToast } = useToast();
-  const { init } = amplitudeInitializer();
-  const { user, setUser } = useUserStore();
 
   const fetchIsUserValid = async () => {
     const { isAccessTokenExist, isRefreshTokenExist } = await getIsUserValid();
@@ -28,11 +22,6 @@ const useAutoLogin = () => {
   };
 
   const autoLogin = async () => {
-    const result = await getUserInfo();
-    setUser(result);
-
-    init(user.userEmail);
-    showToast({ message: `${user?.userName}님, 환영합니다.`, type: 'confirm' });
     return navigate(ROUTE_PATH.home);
   };
 

--- a/frontend/src/hooks/useAutoLogin.ts
+++ b/frontend/src/hooks/useAutoLogin.ts
@@ -5,11 +5,13 @@ import { deleteToken, getIsUserValid, getUserInfo, postReissueAccessToken } from
 import { ROUTE_PATH } from '@/constants/routePath';
 import useToast from '@/hooks/useToast';
 import amplitudeInitializer from '@/service/amplitude/amplitudeInitializer';
+import useUserStore from '@/store/useUserStore';
 
 const useAutoLogin = () => {
   const navigate = useNavigate();
   const { showToast } = useToast();
   const { init } = amplitudeInitializer();
+  const { user, setUser } = useUserStore();
 
   const fetchIsUserValid = async () => {
     const { isAccessTokenExist, isRefreshTokenExist } = await getIsUserValid();
@@ -27,8 +29,10 @@ const useAutoLogin = () => {
 
   const autoLogin = async () => {
     const result = await getUserInfo();
-    init(result.userEmail);
-    showToast({ message: `${result?.userName}님, 환영합니다.`, type: 'confirm' });
+    setUser(result);
+
+    init(user.userEmail);
+    showToast({ message: `${user?.userName}님, 환영합니다.`, type: 'confirm' });
     return navigate(ROUTE_PATH.home);
   };
 

--- a/frontend/src/hooks/useOAuthLogin.ts
+++ b/frontend/src/hooks/useOAuthLogin.ts
@@ -1,20 +1,15 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { getUserInfo } from '@/apis/user';
 import { KAKAO_AUTH_URL } from '@/constants/oAuth';
 import { ROUTE_PATH } from '@/constants/routePath';
 import useAddOAuthUserQuery from '@/hooks/query/useAddOAuthUserQuery';
 import useMutateChecklist from '@/hooks/useMutateChecklist';
-import useToast from '@/hooks/useToast';
-import amplitudeInitializer from '@/service/amplitude/amplitudeInitializer';
 
 const useOAuthLogin = () => {
   const navigate = useNavigate();
   const { mutate: addOAuthUser, isSuccess } = useAddOAuthUserQuery();
   const { handleSubmitChecklist } = useMutateChecklist('add');
-  const { init } = amplitudeInitializer();
-  const { showToast } = useToast();
 
   const currentUrl = new URL(window.location.href);
   currentUrl.searchParams.delete('code');
@@ -28,14 +23,7 @@ const useOAuthLogin = () => {
   }, [addOAuthUser]);
 
   useEffect(() => {
-    const initAmplitudeUser = async () => {
-      const result = await getUserInfo();
-      init(result.userEmail);
-      showToast({ message: `${result?.userName}님, 환영합니다.`, type: 'confirm' });
-    };
-
     if (isSuccess) {
-      initAmplitudeUser();
       if (redirectUri.includes(ROUTE_PATH.checklistNew)) return handleSubmitChecklist();
       else return navigate(ROUTE_PATH.home);
     }

--- a/frontend/src/hooks/useOAuthLogin.ts
+++ b/frontend/src/hooks/useOAuthLogin.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { KAKAO_AUTH_URL } from '@/constants/oAuth';
 import { ROUTE_PATH } from '@/constants/routePath';
-import useAddOAuthUserQuery from '@/hooks/query/useAddOAuthUserQuery';
+import useAddOAuthUserQuery from '@/hooks/query/usePostOAuthUserQuery';
 import useMutateChecklist from '@/hooks/useMutateChecklist';
 
 const useOAuthLogin = () => {

--- a/frontend/src/mocks/fixtures/user.ts
+++ b/frontend/src/mocks/fixtures/user.ts
@@ -5,6 +5,7 @@ export const user: User = {
   userName: '방끗이',
   userEmail: 'bang-ggood@gmail.com',
   createdAt: '2024-08-11T10:00:00Z',
+  userType: 'ADMIN',
 };
 
 export const mockUserTokenValid: UserTokenValid = {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,10 +1,24 @@
 import styled from '@emotion/styled';
-import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { ROUTE_PATH } from '@/constants/routePath';
+import useUserQuery from '@/hooks/query/useUserQuery';
+import useToast from '@/hooks/useToast';
 import { boxShadowSpread, flexRow, title2, title3 } from '@/styles/common';
 
 const AdminPage = () => {
+  const { data: user } = useUserQuery();
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user?.userType !== 'ADMIN') {
+      showToast({ message: '해당 페이지 접근 권한이 없습니다.', type: 'error' });
+      navigate(ROUTE_PATH.root);
+    }
+  }, []);
+
   return (
     <S.PageWrapper>
       <S.QuestionBox>

--- a/frontend/src/pages/ArticleEditorPage.tsx
+++ b/frontend/src/pages/ArticleEditorPage.tsx
@@ -12,7 +12,7 @@ const ArticleEditorPage = () => {
   const [title, setTitle] = useState('');
   const [keyword, setKeyword] = useState('');
   const [summary, setSummary] = useState('');
-  const [thumbnail] = useState('');
+  const [thumbnail, setThumbnail] = useState('');
   const [content, setContent] = useState('# 여기에 아티클을 작성해주세요');
 
   const { mutate: addArticle } = usePostArticleQuery();
@@ -77,6 +77,18 @@ const ArticleEditorPage = () => {
               name="summary"
               id="summary"
               value={summary}
+            />
+          </FormField>
+
+          {/* 썸네일 폼 필드 */}
+          <FormField>
+            <FormField.Label label="썸네일" htmlFor="thumbnail" required />
+            <FormField.Input
+              placeholder="썸네일 사진 url를 입력하세요"
+              onChange={e => setThumbnail(e.target.value)}
+              name="thumbnail"
+              id="thumbnail"
+              value={thumbnail}
             />
           </FormField>
 

--- a/frontend/src/pages/SignInPage.tsx
+++ b/frontend/src/pages/SignInPage.tsx
@@ -2,21 +2,17 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { getUserInfo } from '@/apis/user';
 import { BangBangIcon, BangGgoodTextIcon } from '@/assets/assets';
 import Button from '@/components/_common/Button/Button';
 import FormField from '@/components/_common/FormField/FormField';
 import Header from '@/components/_common/Header/Header';
 import { ROUTE_PATH } from '@/constants/routePath';
 import usePostSignInQuery from '@/hooks/query/usePostSignInQuery';
-import useToast from '@/hooks/useToast';
 import useValidateInput from '@/hooks/useValidateInput';
-import amplitudeInitializer from '@/service/amplitude/amplitudeInitializer';
 import { flexCenter, title3, title4 } from '@/styles/common';
 import { validateEmail } from '@/utils/authValidation';
 
 const SignInPage = () => {
-  const { showToast } = useToast();
   const [postErrorMessage, setPostErrorMessage] = useState('');
   const navigate = useNavigate();
 
@@ -42,19 +38,11 @@ const SignInPage = () => {
   const disabled = !isEmailValidated || !isPasswordValidated;
 
   const { mutate: signIn } = usePostSignInQuery();
-  const { init } = amplitudeInitializer();
 
-  const handleSubmit = async () =>
-    await signIn(
+  const handleSubmit = () =>
+    signIn(
       { email, password },
       {
-        onSuccess: async () => {
-          const result = await getUserInfo();
-          init(result.userEmail);
-
-          showToast({ message: `${result?.userName}님, 환영합니다.`, type: 'confirm' });
-          return navigate(ROUTE_PATH.home);
-        },
         onError: error => setPostErrorMessage(error.message),
       },
     );
@@ -67,7 +55,6 @@ const SignInPage = () => {
 
   const handleMoveToSignUp = () => navigate(ROUTE_PATH.signUp);
   const handleMoveToResetPassword = () => navigate(ROUTE_PATH.resetPassword);
-
   const handleClickBackward = () => navigate(ROUTE_PATH.root);
 
   return (

--- a/frontend/src/service/amplitude/trackEvent.ts
+++ b/frontend/src/service/amplitude/trackEvent.ts
@@ -3,7 +3,7 @@ import { AmplitudeService } from '@/service/amplitude/AmplitudeService';
 const amplitudeService = new AmplitudeService();
 
 // Login Buttons
-export const trackBasicLoginButton = () => {
+export const trackEmailLoginButton = () => {
   amplitudeService.customTrack('[Click] 일반 로그인 버튼');
 };
 

--- a/frontend/src/store/useUserStore.ts
+++ b/frontend/src/store/useUserStore.ts
@@ -6,21 +6,28 @@ import { User } from '@/types/user';
 interface UserState {
   user: User;
   setUser: (user: User) => void;
+  reset: () => void;
 }
+
+const initialUser: User = {
+  userId: 0,
+  userName: '',
+  userEmail: '',
+  createdAt: '',
+  userType: 'GUEST',
+};
 
 const useUserStore = create<UserState>()(
   persist(
     set => ({
-      user: {
-        userId: 0,
-        userName: '',
-        userEmail: '',
-        createdAt: '',
-        userType: 'GUEST',
-      },
+      user: { ...initialUser },
 
       setUser: (newUser: User) => {
         set(() => ({ user: { ...newUser } }));
+      },
+
+      reset: () => {
+        set(() => ({ user: { ...initialUser } }));
       },
     }),
     {

--- a/frontend/src/store/useUserStore.ts
+++ b/frontend/src/store/useUserStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import { User } from '@/types/user';
+
+interface UserState {
+  user: User;
+  setUser: (user: User) => void;
+}
+
+const useUserStore = create<UserState>()(
+  persist(
+    set => ({
+      user: {
+        userId: 0,
+        userName: '',
+        userEmail: '',
+        createdAt: '',
+        userType: 'GUEST',
+      },
+
+      setUser: (newUser: User) => {
+        set(() => ({ user: { ...newUser } }));
+      },
+    }),
+    {
+      name: 'user-info',
+      partialize(state) {
+        return { user: state.user };
+      },
+    },
+  ),
+);
+
+export default useUserStore;

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,7 +1,10 @@
+export type UserType = 'ADMIN' | 'USER' | 'GUEST';
+
 export interface User {
   userId: number;
   userName: string;
   userEmail: string;
+  userType: UserType;
   createdAt: string;
 }
 


### PR DESCRIPTION
## ❗ Issue

- #1017 

## ✨ 구현한 기능

### 유저 타입에 맞게 어드민만 어드민 페이지 접근 가능하게 로직 추가 

기존 백엔드로부터 유저 타입을 전달받지 못해서 비밀 어드민 링크를 걸어놓았던 것과 달리 어드민일 시 마이페이지에서 어드민 페이지로 접근 가능하게 버튼 작업을 해놨습니다. 

<img width="633" alt="스크린샷 2024-12-04 오후 6 53 07" src="https://github.com/user-attachments/assets/3999d89d-6519-4273-94d9-e664c03324f1">

작업하면서 이전에 꾸준히 이야기 나온 유저 스토어도 함께 제작했습니다. 
스토어 사용으로 엠플리튜드나 이후 유저 로직이 사용될 때 UserQuery 를 호출할 필요 없이 유저 타입으로 분기처리를 하면 될거 같습니다. 

아마 다음 피알에서 마이페이지를 리팩토링할 거 같습니다. 
((기존에는 쿼리 호출 후 에러 바운더리로 게스트 / 유저 모드를 나눠서 작업했습니다. 이젠 그럴필요가 없어짐~~!!)) 

추가적으로 로그아웃/탈퇴할 때 스토어 초기화도 당연히 작업해놨습니당 ~~ !! 


## 📢 논의하고 싶은 내용

### 체크리스트 스토어 스토리지를 `localStorage` -> `sessionStorage` 으로 변경

유저 스토어를 만들고 최근 프로젝트를 되돌아 보면서 체크리스트 스토어를 로컬 스토리지로 관리할 필요가 있나 라는 생각이 들고 있습니다. 
zustand persist 기능에서 스토리지를 선택 가능하게 해놨는데 기존에는 디폴트 값인 `localStorage` 를 사용하고 있었지만 이 때문에 탭을 끄고 새로 키더라도 저장되어 발생한 문제들도 여럿 있었던거 같아서 사용자 입력인 체크리스트 폼의 스토리지를 `sessionStorage` 으로 변경하면 어떨까 싶습니다. 

모두 확인하고 정리되면 제가 작업할 수 있을거 같습니다. 
아마 작업하면 유저 스토어는 로컬에 나머지 입력들은 세션으로 저장할거 같습니다. 

찾아본 스토리지 별 사용 예시 

```
**localStorage:**
- 유저의 설정, 인증 토큰, 장기적으로 필요한 데이터 저장.
- 브라우저를 닫아도 유지되어야 하는 데이터를 저장할 때 사용.

**sessionStorage:**
- 페이지 간 잠시 유지해야 하는 상태 정보나 폼 입력 데이터 등.
- 브라우저 탭을 닫으면 사라져도 괜찮은 임시 데이터를 저장할 때 사용.
```


## 🎸 기타

