### PR TITLE
[BE] 체크리스트 작성, 수정 API 요청시 중복된 위도, 경도정보를 삭제한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/dto/request/ChecklistRequestV1.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/dto/request/ChecklistRequestV1.java
@@ -2,13 +2,11 @@ package com.bang_ggood.checklist.dto.request;
 
 import com.bang_ggood.question.dto.request.QuestionRequest;
 import com.bang_ggood.room.dto.request.RoomRequest;
-import com.bang_ggood.station.dto.request.ChecklistStationRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 
 public record ChecklistRequestV1(@Valid RoomRequest room, List<Integer> options,
-                                 @Valid List<QuestionRequest> questions,
-                                 ChecklistStationRequest geolocation) {
+                                 @Valid List<QuestionRequest> questions) {
 
     public ChecklistRequest toChecklistRequest() {
         return new ChecklistRequest(room, options, questions);

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistManageService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistManageService.java
@@ -30,10 +30,10 @@ import com.bang_ggood.question.dto.response.SelectedQuestionResponse;
 import com.bang_ggood.question.service.ChecklistQuestionService;
 import com.bang_ggood.question.service.QuestionService;
 import com.bang_ggood.room.domain.Room;
+import com.bang_ggood.room.dto.request.RoomRequest;
 import com.bang_ggood.room.dto.response.SelectedRoomResponse;
 import com.bang_ggood.room.service.RoomService;
 import com.bang_ggood.station.domain.ChecklistStation;
-import com.bang_ggood.station.dto.request.ChecklistStationRequest;
 import com.bang_ggood.station.dto.response.SubwayStationResponse;
 import com.bang_ggood.station.dto.response.SubwayStationResponses;
 import com.bang_ggood.station.service.ChecklistStationService;
@@ -78,7 +78,7 @@ public class ChecklistManageService {
         createChecklistOptions(checklistRequest, checklist);
         createChecklistQuestions(checklistRequest, checklist);
         createChecklistMaintenances(checklistRequest, checklist);
-        createChecklistStation(checklistRequestV1, checklist);
+        createChecklistStation(checklistRequestV1.room(), checklist);
         return checklist.getId();
     }
 
@@ -108,9 +108,8 @@ public class ChecklistManageService {
         checklistMaintenanceService.createMaintenances(checklistMaintenances);
     }
 
-    private void createChecklistStation(ChecklistRequestV1 checklistRequestV1, Checklist checklist) {
-        ChecklistStationRequest geolocation = checklistRequestV1.geolocation();
-        checklistStationService.createChecklistStations(checklist, geolocation.latitude(), geolocation.longitude());
+    private void createChecklistStation(RoomRequest roomRequest, Checklist checklist) {
+        checklistStationService.createChecklistStations(checklist, roomRequest.latitude(), roomRequest.longitude());
     }
 
     @Transactional(readOnly = true)
@@ -318,7 +317,7 @@ public class ChecklistManageService {
         updateChecklistOptions(checklistRequest, checklist);
         updateChecklistQuestions(checklistRequest, checklist);
         updateChecklistMaintenances(checklistRequest, checklist);
-        updateChecklistStations(checklistRequestV1, checklist);
+        updateChecklistStations(checklistRequestV1.room(), checklist);
     }
 
     private void updateChecklistOptions(ChecklistRequest checklistRequest, Checklist checklist) {
@@ -349,9 +348,9 @@ public class ChecklistManageService {
         checklistMaintenanceService.updateMaintenances(checklist.getId(), checklistMaintenances);
     }
 
-    private void updateChecklistStations(ChecklistRequestV1 checklistRequestV1, Checklist checklist) {
-        double latitude = checklistRequestV1.geolocation().latitude();
-        double longitude = checklistRequestV1.geolocation().longitude();
+    private void updateChecklistStations(RoomRequest roomRequest, Checklist checklist) {
+        double latitude = roomRequest.latitude();
+        double longitude = roomRequest.longitude();
         checklistStationService.updateChecklistStation(checklist, latitude, longitude);
     }
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/station/dto/request/ChecklistStationRequest.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/station/dto/request/ChecklistStationRequest.java
@@ -1,8 +1,0 @@
-package com.bang_ggood.station.dto.request;
-
-public record ChecklistStationRequest(double latitude, double longitude) {
-
-    public static ChecklistStationRequest of(double latitude, double longitude) {
-        return new ChecklistStationRequest(latitude, longitude);
-    }
-}

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/ChecklistFixture.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/ChecklistFixture.java
@@ -13,7 +13,6 @@ import com.bang_ggood.question.QuestionFixture;
 import com.bang_ggood.question.dto.request.QuestionRequest;
 import com.bang_ggood.room.RoomFixture;
 import com.bang_ggood.room.domain.Room;
-import com.bang_ggood.station.dto.request.ChecklistStationRequest;
 import com.bang_ggood.user.UserFixture;
 import com.bang_ggood.user.domain.User;
 import java.util.List;
@@ -124,8 +123,7 @@ public class ChecklistFixture {
                 List.of(Option.REFRIGERATOR.getId(), Option.SINK.getId(), Option.INDUCTION.getId(),
                         Option.SHOE_RACK.getId()),
                 List.of(QUESTION_1_CREATE_REQUEST(), QUESTION_2_CREATE_REQUEST(),
-                        QUESTION_3_CREATE_REQUEST(), QUESTION_5_CREATE_REQUEST()),
-                ChecklistStationRequest.of(38, 127)
+                        QUESTION_3_CREATE_REQUEST(), QUESTION_5_CREATE_REQUEST())
         );
     }
 
@@ -162,8 +160,7 @@ public class ChecklistFixture {
                 RoomFixture.ROOM_UPDATE_REQUEST(), List.of(Option.REFRIGERATOR.getId(), Option.INDUCTION.getId(),
                 Option.BED.getId(), Option.WASHING_MACHINE.getId()),
                 List.of(QUESTION_1_CREATE_REQUEST(), QUESTION_2_CREATE_REQUEST(),
-                        QUESTION_3_CREATE_REQUEST(), QUESTION_5_UPDATE_REQUEST()),
-                ChecklistStationRequest.of(37.5, 127.1)
+                        QUESTION_3_CREATE_REQUEST(), QUESTION_5_UPDATE_REQUEST())
         );
     }
 


### PR DESCRIPTION
## ❗ Issue

- #1021 

## ✨ 구현한 기능

geolocation 정보가 room 내부 정보와 중복되어 삭제합니다.
```java
"geolocation" : {
		    "latitude" : 37.517406150696104,
		    "longitude" : 127.10333134512422
}
```

## 📢 논의하고 싶은 내용



## 🎸 기타

