### PR TITLE
[BE] 지하철 역 응답에 도보 시간 제한을 둔다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/station/domain/SubwayStation.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/station/domain/SubwayStation.java
@@ -7,7 +7,7 @@ public class SubwayStation {
 
     private static final int METER_PER_DEGREE = 111_320;
     // meter per second * minute unit * decreasing speed on open street
-    private static final double AVERAGE_WALKING_SPEED = 1.3 * 60 * 0.4;
+    private static final double AVERAGE_WALKING_SPEED = 1.3 * 60 * 0.7;
 
     private final Integer id;
     private final String name;

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/station/service/SubwayStationService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/station/service/SubwayStationService.java
@@ -11,10 +11,12 @@ import java.util.List;
 public class SubwayStationService {
 
     private static final List<SubwayStation> SUBWAY_STATIONS = SubwayReader.readSubwayStationData();
+    private static final int MAX_WALKING_TIME = 30;
 
     public SubwayStationResponses readNearestStation(double latitude, double longitude) {
         List<SubwayStationResponse> stationResponses = SUBWAY_STATIONS.stream()
                 .map(station -> SubwayStationResponse.of(station, latitude, longitude))
+                .filter(response -> response.getWalkingTime() < MAX_WALKING_TIME)
                 .toList();
 
         return SubwayStationResponses.from(stationResponses);

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/station/service/ChecklistStationServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/station/service/ChecklistStationServiceTest.java
@@ -52,7 +52,7 @@ public class ChecklistStationServiceTest extends IntegrationTestSupport {
     @Test
     void createChecklistStations() {
         // given & when
-        checklistStationService.createChecklistStations(checklist, 38, 127);
+        checklistStationService.createChecklistStations(checklist, 37.517406150696104, 127.10333134512422);
 
         // then
         assertThat(checklistStationRepository.findByChecklist(checklist)).isNotEmpty();

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/station/service/SubwayStationServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/station/service/SubwayStationServiceTest.java
@@ -3,6 +3,7 @@ package com.bang_ggood.station.service;
 import com.bang_ggood.IntegrationTestSupport;
 import com.bang_ggood.station.dto.response.SubwayStationResponse;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -52,6 +53,15 @@ public class SubwayStationServiceTest extends IntegrationTestSupport {
                     assertThat(nextNearest.getStationLine()).containsAll(nextNearestStation.lines);
                 }
         );
+    }
+
+    @DisplayName("도보 30분이 넘는 지하철 역은 보여주지 않는다.")
+    @Test
+    void readNearestStation_over30Minutes() {
+        // given & when
+        List<SubwayStationResponse> responses = subwayStationService.readNearestStation(0, 0)
+                .getStations();
+        assertThat(responses).hasSize(0);
     }
 
     private static class Station {


### PR DESCRIPTION
## ❗ Issue

- #1036

## ✨ 구현한 기능
- 지하철역 도보 30분 제한
- 도보 속도 계수 조절 (0.4 -> 0.7)

## 📢 논의하고 싶은 내용
- 기존 저장된 데이터 처리 방법?

## 🎸 기타

