### PR TITLE
[FE] 리디자인에 따른 체크리스트 리스트 페이지 레이아웃을 재구성한다.

### DIFF
--- a/frontend/src/components/ChecklistList/ChecklistCard.tsx
+++ b/frontend/src/components/ChecklistList/ChecklistCard.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
-import { LocationLineIcon } from '@/assets/assets';
+import { EmptyHomeIcon } from '@/assets/assets';
 import LikeButton from '@/components/_common/Like/LikeButton';
 import { ROUTE_PATH } from '@/constants/routePath';
-import { boxShadow, flexCenter, flexColumn, flexSpaceBetween, omitText, title3 } from '@/styles/common';
+import { flexCenter, flexColumn, flexSpaceBetween, omitText } from '@/styles/common';
 import { ChecklistPreview } from '@/types/checklist';
+import { fontStyle } from '@/utils/fontStyle';
 import formattedDate from '@/utils/formattedDate';
 import { formattedUndefined } from '@/utils/formattedUndefined';
 
@@ -14,7 +15,7 @@ interface Props {
 }
 const ChecklistCard = ({ checklist }: Props) => {
   const navigate = useNavigate();
-  const { checklistId, roomName, address, createdAt, deposit, rent, summary, isLiked } = checklist;
+  const { checklistId, roomName, thumbnail, address, createdAt, deposit, rent, summary, isLiked } = checklist;
 
   const handleMoveToDetail = () => {
     navigate(ROUTE_PATH.checklistOne(checklist.checklistId));
@@ -23,27 +24,35 @@ const ChecklistCard = ({ checklist }: Props) => {
   return (
     <S.Container data-testid="checklist-card" onClick={handleMoveToDetail} tabIndex={1}>
       <S.Row>
-        <S.LocationWrapper>
-          <LocationLineIcon aria-hidden="true" />
-          {formattedUndefined(address, 'string')}
-        </S.LocationWrapper>
+        <S.Row gap="1rem">
+          <div>{thumbnail ? <S.ThumbnailImg src={thumbnail} /> : <EmptyHomeIcon aria-hidden="true" />}</div>
+
+          <S.Column>
+            <S.Location>{formattedUndefined(address, 'string')}</S.Location>
+            <S.Title>{roomName}</S.Title>
+            <S.Deposit>
+              {formattedUndefined(deposit)} / {formattedUndefined(rent)}
+            </S.Deposit>
+          </S.Column>
+        </S.Row>
+
         <LikeButton isLiked={isLiked} checklistId={checklistId} />
       </S.Row>
-      <S.Column>
-        <S.Title>{roomName}</S.Title>
-        <S.Deposit>
-          {formattedUndefined(deposit)} / {formattedUndefined(rent)}
-        </S.Deposit>
-      </S.Column>
+
       <S.Row>
-        <S.SummaryWrapper>
-          <S.SummaryBox>{`"${formattedUndefined(summary, 'string')}"`}</S.SummaryBox>
-        </S.SummaryWrapper>
-        <S.Date>{formattedDate(createdAt ?? '')}</S.Date>
+        <S.GrayBox>
+          <S.Summary>
+            {formattedUndefined(summary, 'string')?.toString().length > 23
+              ? `${formattedUndefined(summary, 'string')?.toString().slice(0, 20)}…`
+              : formattedUndefined(summary, 'string')}
+          </S.Summary>
+          <S.Date>{formattedDate(createdAt ?? '')}</S.Date>
+        </S.GrayBox>
       </S.Row>
     </S.Container>
   );
 };
+
 export default ChecklistCard;
 
 const S = {
@@ -51,56 +60,61 @@ const S = {
     ${flexColumn}
     width: 100%;
     gap: 1rem;
-    box-sizing: border-box;
     border-radius: 0.8rem;
-    padding: 1.2rem 1.6rem;
+    padding: 1.6rem;
+    border: ${({ theme }) => `1px solid ${theme.color.gray[200]}`};
 
-    background-color: ${({ theme }) => theme.palette.white};
-    ${boxShadow};
+    background-color: ${({ theme }) => theme.color.mono.white};
     cursor: pointer;
 
     :hover {
-      background-color: ${({ theme }) => theme.palette.grey200};
+      background-color: ${({ theme }) => theme.color.gray[100]};
     }
   `,
-  Row: styled.div`
+  Row: styled.div<{ gap?: string }>`
     ${flexSpaceBetween}
-    align-items: center;
+    align-items: flex-start;
+    gap: ${({ gap }) => gap};
   `,
   Column: styled.div`
     ${flexColumn}
+    gap: .5rem;
   `,
-  LocationWrapper: styled.p`
+  ThumbnailImg: styled.img`
+    width: 6.8rem;
+    height: 6.8rem;
+    border-radius: 50%;
+    object-fit: cover;
+  `,
+  Location: styled.p`
     ${flexCenter}
     gap: .5rem;
 
-    font-size: ${({ theme }) => theme.text.size.xSmall};
-  `,
-  Date: styled.p`
-    color: ${({ theme }) => theme.palette.grey500};
-    font-size: ${({ theme }) => theme.text.size.xxSmall};
+    ${({ theme }) => fontStyle(theme.font.label[1].R)}
+    color: ${({ theme }) => theme.color.gray[400]};
   `,
   Title: styled.p`
-    ${title3}
-    margin-bottom: 1rem;
+    ${({ theme }) => fontStyle(theme.font.headline[2].B)}
   `,
   Deposit: styled.p`
-    font-size: ${({ theme }) => theme.text.size.medium};
+    ${({ theme }) => fontStyle(theme.font.headline[2].R)}
   `,
-  SummaryWrapper: styled.div`
-    align-items: center;
-    padding: 0.8rem;
+  GrayBox: styled.div`
+    width: 100%;
+    ${flexSpaceBetween}
+    padding: 0.6rem 0.8rem;
 
-    background-color: ${({ theme }) => theme.palette.grey50};
-    border-radius: 0.6rem;
-    box-sizing: content-box;
-    max-width: 70%;
+    background-color: ${({ theme }) => theme.color.gray[100]};
+    border-radius: 0.4rem;
   `,
-  SummaryBox: styled.div`
-    box-sizing: content-box;
+  Summary: styled.span`
     ${omitText};
     border-radius: 0.4rem;
 
-    font-size: ${({ theme }) => theme.text.size.small};
+    ${({ theme }) => fontStyle(theme.font.headline[2].R)}
+  `,
+  Date: styled.span`
+    color: ${({ theme }) => theme.color.gray[400]};
+    ${({ theme }) => fontStyle(theme.font.headline[2].R)}
   `,
 };

--- a/frontend/src/components/ChecklistList/CustomBanner.tsx
+++ b/frontend/src/components/ChecklistList/CustomBanner.tsx
@@ -1,31 +1,26 @@
 import styled from '@emotion/styled';
 
 import Button from '@/components/_common/Button/Button';
-import { boxShadow, flexCenter, flexRow } from '@/styles/common';
+import { flexCenter, flexRow } from '@/styles/common';
+import { fontStyle } from '@/utils/fontStyle';
 
 interface Props {
   onClick?: () => void;
   title: string;
-  buttonColor: string;
+  backgroundColor?: string;
   buttonText: string;
-  Icon: React.ReactElement;
   buttonDetailText: string;
-  hoverButtonColor: string;
+  Icon: React.ReactElement;
 }
 
-const CustomBanner = ({ hoverButtonColor, onClick, Icon, title, buttonColor, buttonText, buttonDetailText }: Props) => {
+const CustomBanner = ({ onClick, Icon, title, buttonText, buttonDetailText, backgroundColor }: Props) => {
   return (
-    <S.Banner onClick={onClick}>
+    <S.Banner onClick={onClick} $backgroundColor={backgroundColor}>
       <S.Wrapper>
         {Icon}
         <S.Title>{title}</S.Title>
       </S.Wrapper>
-      <S.Button
-        aria-label={buttonDetailText}
-        label={buttonText}
-        buttonColor={buttonColor}
-        hoverButtonColor={hoverButtonColor}
-      />
+      <Button label={buttonText} aria-label={buttonDetailText} size="xSmall" />
     </S.Banner>
   );
 };
@@ -33,44 +28,26 @@ const CustomBanner = ({ hoverButtonColor, onClick, Icon, title, buttonColor, but
 export default CustomBanner;
 
 const S = {
-  Banner: styled.div`
+  Banner: styled.div<{ $backgroundColor?: string }>`
     ${flexCenter}
 
     width: 100%;
-    height: 5rem;
+    height: 7.8rem;
     padding: 1.6rem;
 
-    border-radius: 1.6rem;
+    border-radius: 0.8rem;
 
-    background-color: ${({ theme }) => theme.palette.white};
+    background-color: ${({ theme, $backgroundColor }) => ($backgroundColor ? $backgroundColor : theme.color.gray[200])};
 
     box-sizing: border-box;
     justify-content: space-between;
-    align-items: center;
     gap: 0.5rem;
-    ${boxShadow};
   `,
   Wrapper: styled.div`
     ${flexRow}
-    gap: .5rem;
+    gap: .8rem;
   `,
   Title: styled.span`
-    ${flexCenter}
-  `,
-  Button: styled(Button)<{ buttonColor: string; hoverButtonColor: string }>`
-    padding: 0.6rem 1rem;
-
-    background-color: ${({ buttonColor }) => buttonColor};
-
-    color: ${({ theme }) => theme.palette.white};
-    border-radius: 0.8rem;
-
-    font-size: ${({ theme }) => theme.text.size.small};
-
-    cursor: pointer;
-
-    &:hover {
-      background-color: ${({ hoverButtonColor }) => hoverButtonColor};
-    }
+    ${({ theme }) => fontStyle(theme.font.heading[2].B)}
   `,
 };

--- a/frontend/src/components/ChecklistList/CustomBannerSection.tsx
+++ b/frontend/src/components/ChecklistList/CustomBannerSection.tsx
@@ -3,6 +3,7 @@ import FlexBox from '@/components/_common/FlexBox/FlexBox';
 import CustomBanner from '@/components/ChecklistList/CustomBanner';
 import { ROUTE_PATH } from '@/constants/routePath';
 import theme from '@/styles/theme';
+import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
 const CustomBannerSection = () => {
@@ -15,7 +16,7 @@ const CustomBannerSection = () => {
   };
 
   return (
-    <FlexBox.Vertical gap="1rem">
+    <S.BannerSection>
       <CustomBanner
         onClick={handleClickMoveCustomPage}
         Icon={<PencilIcon width={30} height={30} aria-hidden="true" />}
@@ -31,8 +32,17 @@ const CustomBannerSection = () => {
         buttonText="비교하기"
         buttonDetailText={'체크리스트 질문을 편집하려면 이 버튼을 누르세요.'}
       />
-    </FlexBox.Vertical>
+    </S.BannerSection>
   );
 };
 
 export default CustomBannerSection;
+
+const S = {
+  BannerSection: styled(FlexBox.Vertical)`
+    gap: 1.6rem;
+    border-top: ${({ theme }) => `2px solid ${theme.color.gray[100]}`};
+    border-bottom: ${({ theme }) => `2px solid ${theme.color.gray[100]}`};
+    padding: 1.6rem;
+  `,
+};

--- a/frontend/src/components/ChecklistList/CustomBannerSection.tsx
+++ b/frontend/src/components/ChecklistList/CustomBannerSection.tsx
@@ -1,0 +1,38 @@
+import { LampIcon, PencilIcon } from '@/assets/assets';
+import FlexBox from '@/components/_common/FlexBox/FlexBox';
+import CustomBanner from '@/components/ChecklistList/CustomBanner';
+import { ROUTE_PATH } from '@/constants/routePath';
+import theme from '@/styles/theme';
+import { useNavigate } from 'react-router-dom';
+
+const CustomBannerSection = () => {
+  const navigate = useNavigate();
+
+  const handleClickMoveCustomPage = () => navigate(ROUTE_PATH.checklistQuestionSelect);
+
+  const handleClickMoveQuestionSelectPage = () => {
+    navigate(ROUTE_PATH.roomCompareSelect);
+  };
+
+  return (
+    <FlexBox.Vertical gap="1rem">
+      <CustomBanner
+        onClick={handleClickMoveCustomPage}
+        Icon={<PencilIcon width={30} height={30} aria-hidden="true" />}
+        title={'체크리스트 질문 템플릿'}
+        buttonText="편집하기"
+        buttonDetailText={'체크리스트 질문을 편집하려면 이 버튼을 누르세요.'}
+      />
+      <CustomBanner
+        onClick={handleClickMoveQuestionSelectPage}
+        Icon={<LampIcon width={30} height={30} aria-hidden="true" />}
+        title={'체크리스트 비교'}
+        backgroundColor={theme.color.gray[100]}
+        buttonText="비교하기"
+        buttonDetailText={'체크리스트 질문을 편집하려면 이 버튼을 누르세요.'}
+      />
+    </FlexBox.Vertical>
+  );
+};
+
+export default CustomBannerSection;

--- a/frontend/src/components/ChecklistList/LikeFilterButton.tsx
+++ b/frontend/src/components/ChecklistList/LikeFilterButton.tsx
@@ -3,8 +3,9 @@ import styled from '@emotion/styled';
 import Like from '@/assets/icons/like/Like';
 import useGetIsUserValidQuery from '@/hooks/query/useGetIsUserValid';
 import useGetChecklistList from '@/hooks/useGetChecklistList';
-import { boxShadow, flexRow } from '@/styles/common';
+import { flexCenter } from '@/styles/common';
 import theme from '@/styles/theme';
+import { fontStyle } from '@/utils/fontStyle';
 
 const LikeFilterButton = () => {
   const { isLikeFiltered: isEnabled, toggleFilter } = useGetChecklistList();
@@ -24,18 +25,21 @@ const LikeFilterButton = () => {
 export default LikeFilterButton;
 
 const S = {
-  LikeFilterBox: styled.section<{ $isChecked: boolean }>`
-    ${flexRow}
+  LikeFilterBox: styled.button<{ $isChecked: boolean }>`
+    ${flexCenter}
     flex: 0 0 auto;
-    align-items: center;
-    gap: 1rem;
-    box-sizing: border-box;
-    border-radius: 1.5rem;
-    height: 3rem;
-    padding: 1.2rem 1.6rem;
+    gap: 0.5rem;
 
-    background-color: ${({ theme, $isChecked }) => ($isChecked ? theme.palette.red200 : theme.palette.white)};
-    ${boxShadow};
+    box-sizing: border-box;
+    border-radius: 0.8rem;
+
+    width: 11rem;
+    height: 4rem;
+    border: ${({ theme }) => `1px solid ${theme.color.gray[200]}`};
+
+    ${({ theme }) => fontStyle(theme.font.body[1].B)}
+
+    background-color: ${({ theme, $isChecked }) => ($isChecked ? theme.color.gray[200] : theme.color.mono.white)};
     cursor: pointer;
   `,
 };

--- a/frontend/src/components/_common/Button/Button.tsx
+++ b/frontend/src/components/_common/Button/Button.tsx
@@ -147,9 +147,9 @@ const ColorStyles = {
 };
 
 const sizeStyles = {
-  // 현재 디자인에 없는 컴포넌트 하지만 쓰이는 곳이 있어서 추후 삭제 필요
   xSmall: css`
-    min-width: 14rem;
+    min-width: 10rem;
+    height: 4rem;
   `,
   small: css`
     min-width: 14rem;

--- a/frontend/src/components/_common/FloatingButton/FloatingButton.tsx
+++ b/frontend/src/components/_common/FloatingButton/FloatingButton.tsx
@@ -94,13 +94,13 @@ const colorStyle = {
 const S = {
   Wrapper: styled.div`
     display: flex;
-    justify-content: flex-end;
     position: fixed;
-    bottom: calc(5% + ${FOOTER_SIZE}rem);
-    left: 50%;
+    bottom: calc(2% + ${FOOTER_SIZE}rem);
+    left: 55%;
     z-index: ${theme.zIndex.FLOATING_BUTTON};
     width: 100%;
     padding-right: 10%;
+    justify-content: flex-end;
     transform: translateX(-50%);
     max-width: 60rem;
 

--- a/frontend/src/components/_common/layout/Layout.tsx
+++ b/frontend/src/components/_common/layout/Layout.tsx
@@ -12,6 +12,7 @@ interface Props {
   withHeader?: boolean;
   withFooter?: boolean;
   withTab?: boolean;
+  fitContent?: boolean;
 }
 
 const Layout = ({
@@ -20,10 +21,18 @@ const Layout = ({
   withHeader = false,
   withFooter = false,
   withTab = false,
+  fitContent = false,
   style,
 }: Props) => {
   return (
-    <S.Wrapper bgColor={bgColor} style={style} withHeader={withHeader} withFooter={withFooter} withTab={withTab}>
+    <S.Wrapper
+      bgColor={bgColor}
+      style={style}
+      withHeader={withHeader}
+      withFooter={withFooter}
+      withTab={withTab}
+      fitContent={fitContent}
+    >
       {children}
     </S.Wrapper>
   );
@@ -32,17 +41,28 @@ const Layout = ({
 export default Layout;
 
 const S = {
-  Wrapper: styled.main<{ bgColor: string; withHeader: boolean; withFooter: boolean; withTab: boolean }>`
+  Wrapper: styled.main<{
+    bgColor: string;
+    withHeader: boolean;
+    withFooter: boolean;
+    withTab: boolean;
+    fitContent: boolean;
+  }>`
     box-sizing: border-box;
     overflow: hidden auto;
-    ${({ withHeader, withFooter, withTab }) => getHeightStyle(withHeader, withFooter, withTab)}
+    ${({ withHeader, withFooter, withTab, fitContent }) => getHeightStyle(withHeader, withFooter, withTab, fitContent)}
     padding: 1rem 1.6rem;
 
     background-color: ${({ bgColor }) => bgColor};
   `,
 };
 
-const getHeightStyle = (withHeader: boolean, withFooter: boolean, withTab: boolean) => {
+const getHeightStyle = (withHeader: boolean, withFooter: boolean, withTab: boolean, fitContent: boolean) => {
+  if (fitContent) {
+    return css`
+      height: fit-content;
+    `;
+  }
   if (withHeader && withFooter) {
     return css`
       height: calc(100dvh - ${HEADER_SIZE}rem - ${FOOTER_SIZE}rem);

--- a/frontend/src/pages/ChecklistListPage.tsx
+++ b/frontend/src/pages/ChecklistListPage.tsx
@@ -30,11 +30,11 @@ const ChecklistListPage = () => {
 
   return (
     <>
-      <Header center={<Header.Text>체크리스트</Header.Text>} isBorder />
-      <Layout withFooter withHeader>
-        <CustomBannerSection />
-        <S.Spacer height="1.4rem" />
+      <Header center={<Header.Text>체크리스트</Header.Text>} />
+      <CustomBannerSection />
+      <S.Spacer height="1.4rem" />
 
+      <Layout withFooter withHeader>
         <ErrorBoundary fallback={<TitleErrorFallback title="내가 둘러본 방" />}>
           <FlexBox.Horizontal justify="space-between" align="center">
             <ChecklistListTitle />

--- a/frontend/src/pages/ChecklistListPage.tsx
+++ b/frontend/src/pages/ChecklistListPage.tsx
@@ -34,7 +34,7 @@ const ChecklistListPage = () => {
       <CustomBannerSection />
       <S.Spacer height="1.4rem" />
 
-      <Layout withFooter withHeader>
+      <Layout withFooter withHeader fitContent>
         <ErrorBoundary fallback={<TitleErrorFallback title="내가 둘러본 방" />}>
           <FlexBox.Horizontal justify="space-between" align="center">
             <ChecklistListTitle />

--- a/frontend/src/pages/ChecklistListPage.tsx
+++ b/frontend/src/pages/ChecklistListPage.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 
-import { LampIcon, PencilIcon, PlusIcon } from '@/assets/assets';
+import { PlusIcon } from '@/assets/assets';
 import ListErrorFallback from '@/components/_common/errorBoundary/ListErrorFallback';
 import TitleErrorFallback from '@/components/_common/errorBoundary/TitleErrorFallback';
 import FlexBox from '@/components/_common/FlexBox/FlexBox';
@@ -11,24 +11,17 @@ import Header from '@/components/_common/Header/Header';
 import Layout from '@/components/_common/layout/Layout';
 import ChecklistListContainer from '@/components/ChecklistList/ChecklistListContainer';
 import ChecklistListTitle from '@/components/ChecklistList/ChecklistListTitle';
-import CustomBanner from '@/components/ChecklistList/CustomBanner';
+import CustomBannerSection from '@/components/ChecklistList/CustomBannerSection';
 import LikeFilterButton from '@/components/ChecklistList/LikeFilterButton';
 import { ROUTE_PATH } from '@/constants/routePath';
 import { trackAddChecklistButton } from '@/service/amplitude/trackEvent';
 import { useTrackPageView } from '@/service/amplitude/useTrackPageView';
 import { boxShadow, flexRow } from '@/styles/common';
-import theme from '@/styles/theme';
 
 const ChecklistListPage = () => {
   useTrackPageView({ eventName: '[View] 체크리스트 리스트 페이지' });
 
   const navigate = useNavigate();
-
-  const handleClickMoveCustomPage = () => navigate(ROUTE_PATH.checklistQuestionSelect);
-
-  const handleClickMoveQuestionSelectPage = () => {
-    navigate(ROUTE_PATH.roomCompareSelect);
-  };
 
   const handleClickFloatingButton = () => {
     trackAddChecklistButton();
@@ -37,29 +30,11 @@ const ChecklistListPage = () => {
 
   return (
     <>
-      <Header center={<Header.Text>체크리스트</Header.Text>} />
-      <Layout bgColor={theme.palette.background} withFooter withHeader>
-        <FlexBox.Vertical>
-          <CustomBanner
-            onClick={handleClickMoveCustomPage}
-            Icon={<PencilIcon width={30} height={30} aria-hidden="true" />}
-            title={'체크리스트 질문 템플릿'}
-            buttonColor={theme.palette.green500}
-            buttonText="편집하기"
-            buttonDetailText={'체크리스트 질문을 편집하려면 이 버튼을 누르세요.'}
-            hoverButtonColor={theme.palette.green600}
-          />
-          <CustomBanner
-            onClick={handleClickMoveQuestionSelectPage}
-            Icon={<LampIcon width={30} height={30} aria-hidden="true" />}
-            title={'체크리스트 비교'}
-            buttonColor={theme.palette.yellow600}
-            buttonText="비교하기"
-            buttonDetailText={'체크리스트 질문을 편집하려면 이 버튼을 누르세요.'}
-            hoverButtonColor={theme.palette.yellow700}
-          />
-        </FlexBox.Vertical>
+      <Header center={<Header.Text>체크리스트</Header.Text>} isBorder />
+      <Layout withFooter withHeader>
+        <CustomBannerSection />
         <S.Spacer height="1.4rem" />
+
         <ErrorBoundary fallback={<TitleErrorFallback title="내가 둘러본 방" />}>
           <FlexBox.Horizontal justify="space-between" align="center">
             <ChecklistListTitle />
@@ -67,10 +42,12 @@ const ChecklistListPage = () => {
           </FlexBox.Horizontal>
         </ErrorBoundary>
         <S.Spacer height="1rem" />
+
         <ErrorBoundary FallbackComponent={ListErrorFallback}>
           <ChecklistListContainer />
         </ErrorBoundary>
       </Layout>
+
       <FloatingButton size="extends" onClick={handleClickFloatingButton} tabIndex={1}>
         <PlusIcon />방 체크하기
       </FloatingButton>


### PR DESCRIPTION
## ❗ Issue

- #1136 

## ✨ 구현한 기능

### 리디자인에 따른 체크리스트 리스트 페이지 레이아웃을 재구성했습니다. 
변경사항 UI 는 아래와 같습니다~

<피그마 디자인>
![image](https://github.com/user-attachments/assets/8070ff4d-b6dc-47fb-81c0-843e60d7b3d9)

<작업 페이지>
<img width="349" alt="스크린샷 2025-05-03 오후 3 34 44" src="https://github.com/user-attachments/assets/76b7a2ed-39fe-484f-9ce5-0ee29315edf6" />


## 📢 논의하고 싶은 내용



## 🎸 기타

