### PR TITLE
[FE] 방 비교페이지의 모달데이터를 prefetch한다

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,15 +9,13 @@ import router from '@/routers/router';
 import { baseStyle } from '@/styles/global';
 import theme from '@/styles/theme';
 
+export const queryClient = new QueryClient({});
 const App = () => {
-  const { showToast } = useToast();
-
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      mutations: { onError: error => showToast({ message: error.message, type: 'error' }) },
-      queries: { throwOnError: true },
-    },
+  queryClient.setDefaultOptions({
+    mutations: { onError: error => showToast({ message: error.message, type: 'error' }) },
+    queries: { throwOnError: true },
   });
+  const { showToast } = useToast();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,11 +11,11 @@ import theme from '@/styles/theme';
 
 export const queryClient = new QueryClient({});
 const App = () => {
+  const { showToast } = useToast();
   queryClient.setDefaultOptions({
     mutations: { onError: error => showToast({ message: error.message, type: 'error' }) },
     queries: { throwOnError: true },
   });
-  const { showToast } = useToast();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/frontend/src/components/RoomCompare/RoomCompareContent.tsx
+++ b/frontend/src/components/RoomCompare/RoomCompareContent.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import RoomCompareMap from '@/components/_common/Map/RoomCompareMap';
@@ -9,6 +10,7 @@ import OptionDetailModal from '@/components/RoomCompare/OptionDetailModal';
 import SkRoomCompare from '@/components/skeleton/RoomCompare/SkRoomCompare';
 import { OPTIONS } from '@/constants/options';
 import useGetCompareRoomsQuery from '@/hooks/query/useGetCompareRoomsQuery';
+import { prefetchGetRoomCategoryDetailQuery } from '@/hooks/query/useGetRoomCategoryDetail';
 import useModal from '@/hooks/useModal';
 import { OptionDetail } from '@/pages/RoomComparePage';
 import { flexCenter, flexRow } from '@/styles/common';
@@ -24,7 +26,15 @@ const RoomCompareContent = () => {
   const roomId2 = Number(searchParams.get('roomId2'));
 
   const { data: rooms, isLoading } = useGetCompareRoomsQuery(roomId1, roomId2);
-
+  /* 비교 모달데이터를 prefetch 한다 */
+  const categoryIdPairs = rooms?.flatMap(a =>
+    a.categories.categories.flatMap(c => ({ roomId: a.checklistId, categoryId: c.categoryId })),
+  );
+  useEffect(() => {
+    categoryIdPairs?.forEach(categoryIdPair => {
+      prefetchGetRoomCategoryDetailQuery(categoryIdPair);
+    });
+  }, [categoryIdPairs]);
   if (isLoading) return <SkRoomCompare />;
 
   if (!rooms) throw new Error('데이터를 불러오는데 실패했습니다.');

--- a/frontend/src/hooks/query/useGetRoomCategoryDetail.ts
+++ b/frontend/src/hooks/query/useGetRoomCategoryDetail.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getRoomCategoryDetail } from '@/apis/room';
+import { queryClient } from '@/App';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { STALE_TIME } from '@/constants/system';
 import { RoomCategoryDetail } from '@/types/RoomCompare';
@@ -13,4 +14,11 @@ const useGetRoomCategoryDetailQuery = ({ roomId, categoryId }: { roomId: number;
   });
 };
 
+export const prefetchGetRoomCategoryDetailQuery = ({ roomId, categoryId }: { roomId: number; categoryId: number }) => {
+  return queryClient.prefetchQuery({
+    queryKey: [QUERY_KEYS.ROOM_CATEGORY_DETAIL, roomId, categoryId],
+    queryFn: async () => await getRoomCategoryDetail({ roomId, categoryId }),
+    staleTime: STALE_TIME,
+  });
+};
 export default useGetRoomCategoryDetailQuery;


### PR DESCRIPTION
## ❗ Issue

- #1143 

## ✨ 구현한 기능
![image](https://github.com/user-attachments/assets/4ba0ac73-680c-4976-9af4-c7f31696b5ba)
방 비교에서 "방 컨디션"등을 눌렀을 때 뜨는 모달의 데이터를 prefetch하였습니다.

## 📢 논의하고 싶은 내용


## 🎸 기타

느린네트워크에서는 모달 띄우면 loading을 대기해야해서
네트워크가 느린환경(느린 4G 등)에서는 많이유용할거같네요.
