### PR TITLE
[FE] 모달 위치가 왼쪽으로 쏠리는 현상을 해결한다.

### DIFF
--- a/frontend/src/components/_common/Modal/Modal.tsx
+++ b/frontend/src/components/_common/Modal/Modal.tsx
@@ -6,6 +6,7 @@ import { createPortal } from 'react-dom';
 import { CloseIcon } from '@/assets/assets';
 import { fadeIn, fadeOut } from '@/styles/animation';
 import { flexColumn } from '@/styles/common';
+
 import FocusTrap from './FocusTrap/FocusTrap';
 import ModalBody from './ModalBody';
 import ModalFooter from './ModalFooter';
@@ -97,6 +98,7 @@ const S = {
   ModalInner: styled.div<{ isOpen: boolean; backgroundColor: string }>`
     overflow: scroll;
     position: relative;
+    width: 100%;
     padding: 1.6rem;
 
     background-color: ${({ backgroundColor }) => backgroundColor};


### PR DESCRIPTION
## ❗ Issue

- #1155 의 첫번째 항

## ✨ 구현한 기능
![image](https://github.com/user-attachments/assets/9faa4a00-22c2-48dd-b4c2-ba68e65bd736)


## 📢 논의하고 싶은 내용
#1138 에서 ModalInner의 width:100% 를 지웠었는데 그걸 다시 넣어주니까 해결되네요. 
전에는 기존에 내부가 좀 튀어나가는 문제를 고치려고 지웠다고 들었는데 

제 화면에서는 당시 우주가 겪었다고 한 문제가 재현이 안되네요
@tsulocalize 
이 PR코드로
우주 화면에서는 잘 나오는지/내부가 옆으로 튀어나오는지 확인해주시면 감사할거같습니다.

## 🎸 기타

