### PR TITLE
[BE] 체크리스트 삭제 에러를 해결한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistShareService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/checklist/service/ChecklistShareService.java
@@ -2,7 +2,6 @@ package com.bang_ggood.checklist.service;
 
 import com.bang_ggood.checklist.domain.Checklist;
 import com.bang_ggood.checklist.domain.ChecklistShare;
-import com.bang_ggood.checklist.repository.ChecklistRepository;
 import com.bang_ggood.checklist.repository.ChecklistShareRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +13,6 @@ import java.util.UUID;
 public class ChecklistShareService {
 
     private final ChecklistShareRepository checklistShareRepository;
-    private final ChecklistRepository checklistRepository;
 
     @Transactional
     public ChecklistShare createChecklistShare(Checklist checklist) {
@@ -34,6 +32,8 @@ public class ChecklistShareService {
 
     @Transactional
     public void deleteChecklistShare(Checklist checklist) {
-        checklistShareRepository.deleteByChecklistId(checklist.getId());
+        checklistShareRepository
+                .findByChecklistId(checklist.getId())
+                .ifPresent(checklistShare -> checklistShareRepository.deleteByChecklistId(checklist.getId()));
     }
 }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/service/ChecklistShareServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/checklist/service/ChecklistShareServiceTest.java
@@ -4,6 +4,8 @@ import com.bang_ggood.IntegrationTestSupport;
 import com.bang_ggood.checklist.ChecklistFixture;
 import com.bang_ggood.checklist.domain.Checklist;
 import com.bang_ggood.checklist.domain.ChecklistShare;
+import com.bang_ggood.global.exception.BangggoodException;
+import com.bang_ggood.global.exception.ExceptionCode;
 import com.bang_ggood.room.RoomFixture;
 import com.bang_ggood.room.domain.Room;
 import com.bang_ggood.room.repository.RoomRepository;
@@ -15,6 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ChecklistShareServiceTest extends IntegrationTestSupport {
@@ -65,5 +69,37 @@ class ChecklistShareServiceTest extends IntegrationTestSupport {
 
         //then
         assertThat(firstShare).isEqualTo(secondShare);
+    }
+
+    @DisplayName("체크리스트 공유 삭제 성공")
+    @Test
+    void deleteChecklistShare() {
+        // given
+        Room room = roomRepository.save(RoomFixture.ROOM_1());
+        User user = userRepository.save(UserFixture.USER1());
+        Checklist checklist = ChecklistFixture.CHECKLIST1_USER1(room, user);
+        Checklist savedChecklist = checklistService.createChecklist(checklist);
+        ChecklistShare checklistShare = checklistShareService.createChecklistShare(savedChecklist);
+
+        // when
+        checklistShareService.deleteChecklistShare(savedChecklist);
+
+        // then
+        assertThatThrownBy(() -> checklistShareService.readChecklistShare(checklistShare.getToken()))
+                .isInstanceOf(BangggoodException.class)
+                .hasMessage(ExceptionCode.CHECKLIST_SHARE_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("체크리스트 공유가 존재하지 않으면 삭제하지 않음")
+    @Test
+    void deleteChecklistShare_notExist() {
+        Room room = roomRepository.save(RoomFixture.ROOM_1());
+        User user = userRepository.save(UserFixture.USER1());
+        Checklist checklist = ChecklistFixture.CHECKLIST1_USER1(room, user);
+        Checklist savedChecklist = checklistService.createChecklist(checklist);
+
+        // then
+        assertThatCode(() -> checklistShareService.deleteChecklistShare(savedChecklist))
+                .doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## ❗ Issue

- #1182 

## ✨ 구현한 기능

- 문제 원인 : checklist_share 존재하지 않는데 삭제 시도함

  > 2025-07-06 21:49:18 ERROR [http-nio-8080-exec-9] c.b.global.logging.LoggingAspect - requestTime=2025-07-06T21:49:18.997487143, requestUrl='DELETE /checklists/111534', uuid='7b654c96-4503-49a6-98d8-9a42cfbb5d16', errorMessage='JDBC exception executing SQL [update checklist_share cs1_0 join checklist c1_0 on c1_0.id=cs1_0.checklist_id set deleted=1 where c1_0.id=?] [Column 'deleted' in field list is ambiguous]
- 해결 : checklist_share 존재하는 경우에만 삭제하도록 로직 수정

## 📢 논의하고 싶은 내용

## 🎸 기타
