### PR TITLE
[BE] 커스텀 체크리스트 질문 목록에서 디폴트 질문을 분리한다.

### DIFF
--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/dto/response/CategoryCustomChecklistQuestionsResponse.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/dto/response/CategoryCustomChecklistQuestionsResponse.java
@@ -2,10 +2,15 @@ package com.bang_ggood.question.dto.response;
 
 import java.util.List;
 
-public record CategoryCustomChecklistQuestionsResponse(List<CategoryCustomChecklistQuestionResponse> categories) {
+public record CategoryCustomChecklistQuestionsResponse(
+        List<CategoryCustomChecklistQuestionResponse> defaultCategories,
+        List<CategoryCustomChecklistQuestionResponse> userCategories
+) {
 
-    public static CategoryCustomChecklistQuestionsResponse from(
-            List<CategoryCustomChecklistQuestionResponse> categories) {
-        return new CategoryCustomChecklistQuestionsResponse(categories);
+    public static CategoryCustomChecklistQuestionsResponse of(
+            List<CategoryCustomChecklistQuestionResponse> defaultCategories,
+            List<CategoryCustomChecklistQuestionResponse> userCategories
+    ) {
+        return new CategoryCustomChecklistQuestionsResponse(defaultCategories, userCategories);
     }
 }

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/repository/QuestionRepository.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/repository/QuestionRepository.java
@@ -24,10 +24,9 @@ public interface QuestionRepository extends JpaRepository<Question, Integer> {
     @Query("""
             SELECT q FROM Question q
             WHERE q.category.id = :categoryId
-            AND q.user.id IN (:userId, :adminId) """)
-    List<Question> findAllByCategoryIdAndUserIdAndAdminId(@Param("categoryId") Integer categoryId,
-                                                          @Param("userId") Long userId,
-                                                          @Param("adminId") Long adminId);
+            AND q.user.id = :userId""")
+    List<Question> findAllByCategoryIdAndUserId(@Param("categoryId") Integer categoryId,
+                                                          @Param("userId") Long userId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Transactional

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionManageService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionManageService.java
@@ -101,11 +101,11 @@ public class QuestionManageService {
         User admin = userRepository.findUserByUserType(UserType.ADMIN).get(0);
 
         return CategoryCustomChecklistQuestionsResponse.of(
-                readCustomQuestions(customChecklistQuestions, admin),
-                readCustomQuestions(customChecklistQuestions, user));
+                categorizeCustomQuestions(customChecklistQuestions, admin),
+                categorizeCustomQuestions(customChecklistQuestions, user));
     }
 
-    private List<CategoryCustomChecklistQuestionResponse> readCustomQuestions(List<CustomChecklistQuestion> customChecklistQuestions, User user) {
+    private List<CategoryCustomChecklistQuestionResponse> categorizeCustomQuestions(List<CustomChecklistQuestion> customChecklistQuestions, User user) {
         List<CategoryCustomChecklistQuestionResponse> response = new ArrayList<>();
         for (Category category : questionService.readAllCategories()) {
             List<Question> categoryQuestions = questionService.readQuestionsByCategoryAndUser(category, user);

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionManageService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionManageService.java
@@ -99,11 +99,16 @@ public class QuestionManageService {
     private CategoryCustomChecklistQuestionsResponse categorizeAllQuestionsWithSelected(
             List<CustomChecklistQuestion> customChecklistQuestions, User user) {
         User admin = userRepository.findUserByUserType(UserType.ADMIN).get(0);
-        List<CategoryCustomChecklistQuestionResponse> response = new ArrayList<>();
 
+        return CategoryCustomChecklistQuestionsResponse.of(
+                readCustomQuestions(customChecklistQuestions, admin),
+                readCustomQuestions(customChecklistQuestions, user));
+    }
+
+    private List<CategoryCustomChecklistQuestionResponse> readCustomQuestions(List<CustomChecklistQuestion> customChecklistQuestions, User user) {
+        List<CategoryCustomChecklistQuestionResponse> response = new ArrayList<>();
         for (Category category : questionService.readAllCategories()) {
-            List<Question> categoryQuestions = questionService.readQuestionsByCategoryAndUserAndAdmin(category, user,
-                    admin);
+            List<Question> categoryQuestions = questionService.readQuestionsByCategoryAndUser(category, user);
             List<CustomChecklistQuestionResponse> questions = categoryQuestions.stream()
                     .map(question -> new CustomChecklistQuestionResponse(
                             question,
@@ -112,8 +117,7 @@ public class QuestionManageService {
                     .toList();
             response.add(CategoryCustomChecklistQuestionResponse.of(category, questions));
         }
-
-        return CategoryCustomChecklistQuestionsResponse.from(response);
+        return response;
     }
 
     @Transactional(readOnly = true)

--- a/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionService.java
+++ b/backend/bang-ggood/src/main/java/com/bang_ggood/question/service/QuestionService.java
@@ -96,10 +96,9 @@ public class QuestionService {
         return highlightRepository.findAllByQuestionId(questionId);
     }
 
-    @Cacheable(cacheNames = QUESTION, key = "#category")
     @Transactional(readOnly = true)
-    public List<Question> readQuestionsByCategoryAndUserAndAdmin(Category category, User user, User admin) {
-        return questionRepository.findAllByCategoryIdAndUserIdAndAdminId(category.getId(), user.getId(), admin.getId());
+    public List<Question> readQuestionsByCategoryAndUser(Category category, User user) {
+        return questionRepository.findAllByCategoryIdAndUserId(category.getId(), user.getId());
     }
 
     @Transactional

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/QuestionRepositoryTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/repository/QuestionRepositoryTest.java
@@ -7,11 +7,13 @@ import com.bang_ggood.question.domain.Question;
 import com.bang_ggood.user.UserFixture;
 import com.bang_ggood.user.domain.User;
 import com.bang_ggood.user.repository.UserRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class QuestionRepositoryTest extends IntegrationTestSupport {
 
@@ -34,11 +36,14 @@ class QuestionRepositoryTest extends IntegrationTestSupport {
         Question question3 = questionRepository.save(new Question(category2, user, "title", "subtitle", false));
 
         // when
-        List<Question> questions = questionRepository.findAllByCategoryIdAndUserIdAndAdminId(category1.getId(),
-                user.getId(), admin.getId());
+        List<Question> userQuestions = questionRepository.findAllByCategoryIdAndUserId(category1.getId(), user.getId());
+        List<Question> adminQuestions = questionRepository.findAllByCategoryIdAndUserId(category1.getId(), admin.getId());
 
         // then
-        Assertions.assertThat(questions).containsOnly(question1, question2);
+        assertAll(() -> {
+            assertThat(userQuestions).containsOnly(question1);
+            assertThat(adminQuestions).containsOnly(question2);
+        });
     }
 
     @DisplayName("디폴트 체크리스트 조회 성공")
@@ -54,8 +59,8 @@ class QuestionRepositoryTest extends IntegrationTestSupport {
         List<Question> questions = questionRepository.findAllByIsDefaultTrue();
 
         // then
-        Assertions.assertThat(questions).contains(defaultQuestion);
-        Assertions.assertThat(questions).doesNotContain(notDefaultQuestion);
+        assertThat(questions).contains(defaultQuestion);
+        assertThat(questions).doesNotContain(notDefaultQuestion);
     }
 
     @DisplayName("체크리스트 id로 조회 성공")
@@ -69,7 +74,7 @@ class QuestionRepositoryTest extends IntegrationTestSupport {
         List<Question> questions = questionRepository.findAllByIdIn(List.of(question1.getId(), question2.getId()));
 
         // then
-        Assertions.assertThat(questions).containsExactly(question1, question2);
+        assertThat(questions).containsExactly(question1, question2);
     }
 
     @DisplayName("질문 삭제 성공")
@@ -83,6 +88,6 @@ class QuestionRepositoryTest extends IntegrationTestSupport {
         List<Question> result = questionRepository.findAllByIdIn(List.of(question1.getId()));
 
         // then
-        Assertions.assertThat(result).isEmpty();
+        assertThat(result).isEmpty();
     }
 }

--- a/backend/bang-ggood/src/test/java/com/bang_ggood/question/service/QuestionManageServiceTest.java
+++ b/backend/bang-ggood/src/test/java/com/bang_ggood/question/service/QuestionManageServiceTest.java
@@ -15,6 +15,7 @@ import com.bang_ggood.question.domain.CustomChecklistQuestion;
 import com.bang_ggood.question.domain.Question;
 import com.bang_ggood.question.dto.request.CustomChecklistUpdateRequest;
 import com.bang_ggood.question.dto.request.QuestionCreateRequest;
+import com.bang_ggood.question.dto.response.CategoryCustomChecklistQuestionsResponse;
 import com.bang_ggood.question.dto.response.CategoryQuestionsResponse;
 import com.bang_ggood.question.dto.response.ComparisonCategorizedQuestionsResponse;
 import com.bang_ggood.question.dto.response.CustomChecklistQuestionsResponse;
@@ -188,5 +189,21 @@ class QuestionManageServiceTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> questionManageService.updateCustomChecklist(UserFixture.USER1, request))
                 .isInstanceOf(BangggoodException.class)
                 .hasMessage(ExceptionCode.QUESTION_INVALID.getMessage());
+    }
+
+    @DisplayName("커스텀 체크리스트 질문 조회 성공 : 유저가 생성한 질문 별도 분리")
+    @Test
+    void readAllCustomChecklistQuestions() {
+        // given
+        User user = UserFixture.USER1;
+
+        // when
+        CategoryCustomChecklistQuestionsResponse response = questionManageService.readAllCustomChecklistQuestions(user);
+
+        // then
+        assertThat(response.defaultCategories().stream().flatMap(it -> it.questions().stream()))
+                .hasSize(32);
+        assertThat(response.userCategories().stream().flatMap(it -> it.questions().stream()))
+                .hasSize(5);
     }
 }


### PR DESCRIPTION
## ❗ Issue

- #1184 

## ✨ 구현한 기능
유저가 생성한 질문과 기본 질문(어드민 질문)을 분리해서 response에 담는다.

## 📢 논의하고 싶은 내용
기존에 있던 `#category` 기반 캐싱이 "유저가 달라질 때", "어드민 질문이 추가/삭제될 때" 문제가 있을 것 같아 제거했습니다.
필요하다고 판단되시면 회의때 논의하면 좋을 것 같습니다.


## 🎸 기타

