### PR TITLE
[FE] 커스텀 질문 추가/필터 기능을 완성한다

### DIFF
--- a/frontend/src/apis/checklist.ts
+++ b/frontend/src/apis/checklist.ts
@@ -1,17 +1,18 @@
 import fetcher from '@/apis/fetcher';
 import { BASE_URL, ENDPOINT } from '@/apis/url';
-import { roomInfoApiMapper } from '@/store/roomInfoStore';
+import { roomInfoApiPostMapper } from '@/store/roomInfoStore';
 import {
   ChecklistCategoryWithIsSelected,
   ChecklistInfo,
   ChecklistPostForm,
+  ChecklistPreview,
   ChecklistSelectedQuestions,
 } from '@/types/checklist';
 import { mapObjNullToUndefined } from '@/utils/typeFunctions';
 
 export const getChecklistQuestions = async () => {
   const response = await fetcher.get({ url: BASE_URL + ENDPOINT.CHECKLIST_QUESTION });
-  const data = await response.json();
+  const data = (await response.json()) as { categories: ChecklistCategoryWithIsSelected[] };
   return data.categories;
 };
 
@@ -38,18 +39,18 @@ export const getChecklists = async (isLikeFiltered: boolean = false) => {
     url: BASE_URL + (isLikeFiltered ? ENDPOINT.CHECKLISTS_LIKE_V1 : ENDPOINT.CHECKLISTS_V1),
   });
   const data = await response.json();
-  return data.checklists.map(mapObjNullToUndefined);
+  return data.checklists.map(mapObjNullToUndefined) as ChecklistPreview[];
 };
 
 export const postChecklist = async (checklist: ChecklistPostForm) => {
-  const mappedRoomInfo = roomInfoApiMapper(checklist.room);
+  const mappedRoomInfo = roomInfoApiPostMapper(checklist.room);
   const mappedChecklist = { ...checklist, room: mappedRoomInfo };
   const response = await fetcher.post({ url: BASE_URL + ENDPOINT.CHECKLISTS_V1, body: mappedChecklist });
   return response;
 };
 
 export const putChecklist = async (id: number, checklist: ChecklistPostForm) => {
-  const mappedRoomInfo = roomInfoApiMapper(checklist.room);
+  const mappedRoomInfo = roomInfoApiPostMapper(checklist.room);
   const mappedChecklist = { ...checklist, room: mappedRoomInfo };
   const response = await fetcher.put({ url: BASE_URL + ENDPOINT.CHECKLIST_ID_V1(id), body: mappedChecklist });
   return response;

--- a/frontend/src/apis/checklist.ts
+++ b/frontend/src/apis/checklist.ts
@@ -24,7 +24,7 @@ export const getChecklistAllQuestions = async () => {
 
 export interface CustomChecklistCategoriesRes {
   defaultCategories: ChecklistCategoryWithIsSelected[];
-  UserCategories: ChecklistCategoryWithIsSelected[];
+  userCategories: ChecklistCategoryWithIsSelected[];
 }
 
 export const getChecklistDetail = async (id: number) => {

--- a/frontend/src/apis/room.ts
+++ b/frontend/src/apis/room.ts
@@ -1,14 +1,15 @@
 import fetcher from '@/apis/fetcher';
 import { BASE_URL, ENDPOINT } from '@/apis/url';
+import { RoomCategoryDetail, RoomCompare } from '@/types/RoomCompare';
 
 export const getRoomCompare = async (roomId1: number, roomId2: number) => {
   const response = await fetcher.get({ url: BASE_URL + ENDPOINT.ROOM_COMPARE(roomId1, roomId2) });
-  const data = await response.json();
+  const data = (await response.json()) as { checklists: RoomCompare[] };
   return data.checklists;
 };
 
 export const getRoomCategoryDetail = async ({ roomId, categoryId }: { roomId: number; categoryId: number }) => {
   const response = await fetcher.get({ url: BASE_URL + ENDPOINT.ROOM_CATEGORY_DETAIL(roomId, categoryId) });
   const data = await response.json();
-  return data;
+  return data as RoomCategoryDetail;
 };

--- a/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/AddCustomQuestionModal.tsx
+++ b/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/AddCustomQuestionModal.tsx
@@ -1,0 +1,49 @@
+import Button from '@/components/_common/Button/Button';
+import FormField from '@/components/_common/FormField/FormField';
+import Modal from '@/components/_common/Modal/Modal';
+import ModalBody from '@/components/_common/Modal/ModalBody';
+import ModalHeader from '@/components/_common/Modal/ModalHeader';
+import { useTabContext } from '@/components/_common/Tabs/TabContext';
+import Text from '@/components/_common/Text/Text';
+import { RequestParamPostCustomQuestion } from '@/hooks/query/usePostCustomQuestionMutation';
+import useInput from '@/hooks/useInput';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (question: RequestParamPostCustomQuestion) => void;
+}
+
+function AddCustomQuestionModal({ isOpen, onClose, onConfirm }: Props) {
+  const { currentTabId } = useTabContext();
+  const { value, onChange } = useInput('');
+
+  return (
+    <Modal isOpen={isOpen} hasCloseButton onClose={onClose} position="bottom">
+      <ModalHeader title="내 질문 추가" />
+      <ModalBody>
+        <FormField>
+          <FormField.Input
+            value={value}
+            onChange={onChange}
+            width="full"
+            placeholder="나에게 필요한 질문을 직접 추가할 수 있어요."
+            variant="default"
+          />
+        </FormField>
+        <Text typography={font => font.caption[1].R} color={theme => theme.gray[400]}>
+          기본 질문 외에도 스스로 궁금한 점을 직접 추가할 수 있어요. 나만의 체크리스트를 만들어 보세요.
+        </Text>
+        <Button
+          color="primary"
+          label="완료"
+          onClick={() => onConfirm({ categoryId: currentTabId, title: value, subtitle: '' })}
+          size="full"
+          style={{ marginTop: '2rem' }}
+        />
+      </ModalBody>
+    </Modal>
+  );
+}
+
+export default AddCustomQuestionModal;

--- a/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/QuestionCardListCustom.tsx
+++ b/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/QuestionCardListCustom.tsx
@@ -8,18 +8,18 @@ import { ChecklistQuestionWithIsSelected } from '@/types/checklist';
 interface Props {
   currentTabId: number;
   questions: ChecklistQuestionWithIsSelected[];
-  onSelect?: (id: number) => void;
+  onSelect: (id: number) => void;
+  selectedIds: number[];
 }
-const QuestionCardList = ({ questions, currentTabId, onSelect }: Props) => {
+const QuestionCardListCustom = ({ questions, currentTabId, onSelect, selectedIds }: Props) => {
   return (
     <S.QuestionList>
       {questions?.map((question, index) => {
+        const isSelected = selectedIds.includes(question.questionId);
         return (
           <S.Box key={`${currentTabId}-${question.questionId}-custom`}>
-            <QuestionSelectCard
-              question={question}
-              onSelect={onSelect ? () => onSelect(question.questionId) : undefined}
-            />
+            {isSelected}
+            <QuestionSelectCard question={{ ...question, isSelected }} onSelect={() => onSelect(question.questionId)} />
             {index !== questions.length - 1 && <Divider isBold={true} />}
           </S.Box>
         );
@@ -28,7 +28,7 @@ const QuestionCardList = ({ questions, currentTabId, onSelect }: Props) => {
   );
 };
 
-export default QuestionCardList;
+export default QuestionCardListCustom;
 
 const S = {
   QuestionList: styled.section`

--- a/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/QuestionCustomListTemplate.tsx
+++ b/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/QuestionCustomListTemplate.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import { useStore } from 'zustand';
 
 import Button from '@/components/_common/Button/Button';
 import { useTabContext } from '@/components/_common/Tabs/TabContext';
 import Text from '@/components/_common/Text/Text';
 import AddCustomQuestionModal from '@/components/ChecklistQuestionSelect/CustomQuestions/AddCustomQuestionModal';
 import QuestionCardListCustom from '@/components/ChecklistQuestionSelect/CustomQuestions/QuestionCardListCustom';
+import { selectedIdsStore } from '@/components/ChecklistQuestionSelect/CustomQuestions/selectedQuestionIdsStore';
 import SKQuestionSelectList from '@/components/skeleton/QuestionSelect/SKQuestionSelectList';
 import useGetAllChecklistQuestionQuery from '@/hooks/query/useGetAllChecklistQuestionsQuery';
 import usePostCustomQuestionMutation, {
@@ -17,15 +19,8 @@ const QuestionCustomListTemplate = () => {
   const { mutate: addCustomQuestion } = usePostCustomQuestionMutation();
   const customCategories = checklistQuestions?.userCategories;
 
-  const [selectedIds, setSelectedIds] = useState<number[]>(
-    customCategories
-      ?.flatMap(cat => cat.questions)
-      .filter(q => q.isSelected)
-      .map(q => q.questionId) ?? [],
-  );
-  const handleSelect = (id: number) => {
-    setSelectedIds(ids => (ids.includes(id) ? ids.filter(id0 => id0 !== id) : [...ids, id]));
-  };
+  const { selectedIds, toggleSelectedId } = useStore(selectedIdsStore);
+  const handleSelect = (id: number) => toggleSelectedId(id);
 
   const [isAddCustomQuestionModalOpen, setIsAddCustomQuestionModalOpen] = useState(false);
   const { currentTabId } = useTabContext();
@@ -50,8 +45,6 @@ const QuestionCustomListTemplate = () => {
         onSelect={handleSelect}
         selectedIds={selectedIds}
       />
-      {JSON.stringify(selectedIds)}
-      {/* 결과 */}
       <Button
         variant="outlined-gray"
         size="full"

--- a/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/QuestionCustomListTemplate.tsx
+++ b/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/QuestionCustomListTemplate.tsx
@@ -1,0 +1,99 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+
+import Button from '@/components/_common/Button/Button';
+import { useTabContext } from '@/components/_common/Tabs/TabContext';
+import Text from '@/components/_common/Text/Text';
+import AddCustomQuestionModal from '@/components/ChecklistQuestionSelect/CustomQuestions/AddCustomQuestionModal';
+import QuestionCardListCustom from '@/components/ChecklistQuestionSelect/CustomQuestions/QuestionCardListCustom';
+import SKQuestionSelectList from '@/components/skeleton/QuestionSelect/SKQuestionSelectList';
+import useGetAllChecklistQuestionQuery from '@/hooks/query/useGetAllChecklistQuestionsQuery';
+import usePostCustomQuestionMutation, {
+  RequestParamPostCustomQuestion,
+} from '@/hooks/query/usePostCustomQuestionMutation';
+
+const QuestionCustomListTemplate = () => {
+  const { data: checklistQuestions, isLoading } = useGetAllChecklistQuestionQuery();
+  const { mutate: addCustomQuestion } = usePostCustomQuestionMutation();
+  const customCategories = checklistQuestions?.userCategories;
+
+  const [selectedIds, setSelectedIds] = useState<number[]>(
+    customCategories
+      ?.flatMap(cat => cat.questions)
+      .filter(q => q.isSelected)
+      .map(q => q.questionId) ?? [],
+  );
+  const handleSelect = (id: number) => {
+    setSelectedIds(ids => (ids.includes(id) ? ids.filter(id0 => id0 !== id) : [...ids, id]));
+  };
+
+  const [isAddCustomQuestionModalOpen, setIsAddCustomQuestionModalOpen] = useState(false);
+  const { currentTabId } = useTabContext();
+
+  const currentCategoryQnA = customCategories?.filter(category => category.categoryId === currentTabId)[0];
+
+  if (isLoading) return <SKQuestionSelectList />;
+
+  return (
+    <S.Container>
+      <S.Row>
+        <Text typography={font => font.headline[2].B} color={theme => theme.mono.black}>
+          내가 추가한 질문
+        </Text>
+        <Button variant="outlined-gray" size="small" onClick={() => {}} label="삭제하기" />
+      </S.Row>
+
+      <QuestionCardListCustom
+        key={`${currentTabId}-customList`}
+        currentTabId={currentTabId}
+        questions={currentCategoryQnA?.questions ?? []}
+        onSelect={handleSelect}
+        selectedIds={selectedIds}
+      />
+      {JSON.stringify(selectedIds)}
+      {/* 결과 */}
+      <Button
+        variant="outlined-gray"
+        size="full"
+        onClick={() => setIsAddCustomQuestionModalOpen(true)}
+        label="질문추가"
+      />
+      <AddCustomQuestionModal
+        isOpen={isAddCustomQuestionModalOpen}
+        onClose={() => {
+          setIsAddCustomQuestionModalOpen(false);
+        }}
+        onConfirm={(question: RequestParamPostCustomQuestion) => {
+          addCustomQuestion(question);
+        }}
+      />
+    </S.Container>
+  );
+};
+
+const S = {
+  Container: styled.article`
+    width: 100%;
+    margin: 1.6rem -1.6rem 0;
+    padding: 1.6rem;
+    background: white;
+  `,
+  Row: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  `,
+  Span: styled.div`
+    color: ${({ theme }) => theme.color.gray[500]};
+  `,
+  CounterBox: styled.section`
+    display: flex;
+    margin-bottom: 1.6rem;
+    padding: 1.2rem;
+    justify-content: right;
+    gap: 1rem;
+    align-items: center;
+  `,
+};
+
+export default QuestionCustomListTemplate;

--- a/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/QuestionSelectCardCustom.tsx
+++ b/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/QuestionSelectCardCustom.tsx
@@ -2,29 +2,19 @@ import styled from '@emotion/styled';
 
 import Checkbox from '@/components/_common/Checkbox/Checkbox';
 import FlexBox from '@/components/_common/FlexBox/FlexBox';
-import { useTabContext } from '@/components/_common/Tabs/TabContext';
-import useChecklistQuestionSelect from '@/hooks/useChecklistQuestionSelect';
 import { ChecklistQuestionWithIsSelected } from '@/types/checklist';
 import { fontStyle } from '@/utils/fontStyle';
 
-const QuestionSelectCard = ({
+const QuestionSelectCardCustom = ({
   question,
   onSelect,
 }: {
   question: ChecklistQuestionWithIsSelected;
-  onSelect?: () => void;
+  onSelect: () => void;
 }) => {
   const { title, subtitle, isSelected, questionId } = question;
-  const { toggleQuestionSelect, statusMessage } = useChecklistQuestionSelect();
-  const { currentTabId: categoryId } = useTabContext();
 
-  const handleCheckQuestion = () => {
-    if (onSelect) {
-      onSelect();
-      return;
-    }
-    toggleQuestionSelect({ questionId, isSelected: !isSelected, categoryId });
-  };
+  const handleCheckQuestion = onSelect;
 
   return (
     <>
@@ -47,16 +37,11 @@ const QuestionSelectCard = ({
           tabIndex={-1}
         />
       </S.Container>
-      {statusMessage && (
-        <div className="visually-hidden" role="alert">
-          {title + statusMessage}
-        </div>
-      )}
     </>
   );
 };
 
-export default QuestionSelectCard;
+export default QuestionSelectCardCustom;
 
 const S = {
   Container: styled.div<{ isChecked: boolean }>`

--- a/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/selectedQuestionIdsStore.ts
+++ b/frontend/src/components/ChecklistQuestionSelect/CustomQuestions/selectedQuestionIdsStore.ts
@@ -1,0 +1,14 @@
+import { createStore } from 'zustand';
+
+interface Store {
+  selectedIds: number[];
+  toggleSelectedId: (id: number) => void;
+}
+
+export const selectedIdsStore = createStore<Store>((set, get) => ({
+  selectedIds: [],
+  toggleSelectedId: (id: number) => {
+    const ids = get().selectedIds;
+    set({ selectedIds: ids.includes(id) ? ids.filter(id0 => id0 !== id) : [...ids, id] });
+  },
+}));

--- a/frontend/src/components/NewChecklist/NewRoomInfoForm/useDefaultRoomName.ts
+++ b/frontend/src/components/NewChecklist/NewRoomInfoForm/useDefaultRoomName.ts
@@ -12,9 +12,10 @@ const useDefaultRoomName = () => {
   useEffect(() => {
     if (!checklistList) return;
     if (roomName.rawValue !== initialRoomInfo.roomName.rawValue) return;
+
     const count = checklistList.filter(
       checklist =>
-        new Date(checklist.createdAt).getUTCDay() === new Date().getUTCDay() &&
+        new Date(checklist.createdAt!).getUTCDay() === new Date().getUTCDay() &&
         checklist.roomName !== '예시용 체크리스트',
     ).length;
 

--- a/frontend/src/hooks/query/useGetChecklistDetailQuery.ts
+++ b/frontend/src/hooks/query/useGetChecklistDetailQuery.ts
@@ -2,10 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getChecklistDetail } from '@/apis/checklist';
 import { QUERY_KEYS } from '@/constants/queryKeys';
-import { ChecklistInfo } from '@/types/checklist';
 
 const useGetChecklistDetailQuery = (checklistId: string) => {
-  return useQuery<ChecklistInfo>({
+  return useQuery({
     queryKey: [QUERY_KEYS.CHECKLIST, checklistId],
     queryFn: () => getChecklistDetail(Number(checklistId)),
   });

--- a/frontend/src/hooks/query/useGetChecklistListQuery.ts
+++ b/frontend/src/hooks/query/useGetChecklistListQuery.ts
@@ -3,10 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 import { getChecklists } from '@/apis/checklist';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { STALE_TIME } from '@/constants/system';
-import { ChecklistPreview } from '@/types/checklist';
 
 const useGetChecklistListQuery = (isLikeFiltered: boolean = false) => {
-  return useQuery<ChecklistPreview[]>({
+  return useQuery({
     queryKey: [QUERY_KEYS.CHECKLIST_LIST, isLikeFiltered],
     queryFn: async () => await getChecklists(isLikeFiltered),
     staleTime: STALE_TIME,

--- a/frontend/src/hooks/query/useGetChecklistQuestionQuery.ts
+++ b/frontend/src/hooks/query/useGetChecklistQuestionQuery.ts
@@ -2,10 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getChecklistQuestions } from '@/apis/checklist';
 import { QUERY_KEYS } from '@/constants/queryKeys';
-import { ChecklistCategory } from '@/types/checklist';
 
 const useGetChecklistQuestionQuery = () => {
-  return useQuery<ChecklistCategory[]>({
+  return useQuery({
     queryKey: [QUERY_KEYS.CHECKLIST_QUESTIONS],
     queryFn: getChecklistQuestions,
   });

--- a/frontend/src/hooks/query/useGetCompareRoomsQuery.ts
+++ b/frontend/src/hooks/query/useGetCompareRoomsQuery.ts
@@ -3,10 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 import { getRoomCompare } from '@/apis/room';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { STALE_TIME } from '@/constants/system';
-import { RoomCompare } from '@/types/RoomCompare';
 
 const useGetCompareRoomsQuery = (roomId1: number, roomId2: number) => {
-  return useQuery<RoomCompare[]>({
+  return useQuery({
     queryKey: [QUERY_KEYS.ROOM_COMPARE, roomId1, roomId2],
     queryFn: async () => await getRoomCompare(roomId1, roomId2),
     staleTime: STALE_TIME,

--- a/frontend/src/hooks/query/useGetIsUserValid.ts
+++ b/frontend/src/hooks/query/useGetIsUserValid.ts
@@ -4,7 +4,7 @@ import { getIsUserValid } from '@/apis/user';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 
 const useGetIsUserValidQuery = () => {
-  return useQuery<Awaited<ReturnType<typeof getIsUserValid>>>({
+  return useQuery({
     queryKey: [QUERY_KEYS.AUTH, QUERY_KEYS.IS_USER_VALID],
     queryFn: getIsUserValid,
   });

--- a/frontend/src/hooks/query/useGetRoomCategoryDetail.ts
+++ b/frontend/src/hooks/query/useGetRoomCategoryDetail.ts
@@ -4,10 +4,9 @@ import { getRoomCategoryDetail } from '@/apis/room';
 import { queryClient } from '@/App';
 import { QUERY_KEYS } from '@/constants/queryKeys';
 import { STALE_TIME } from '@/constants/system';
-import { RoomCategoryDetail } from '@/types/RoomCompare';
 
 const useGetRoomCategoryDetailQuery = ({ roomId, categoryId }: { roomId: number; categoryId: number }) => {
-  return useQuery<RoomCategoryDetail>({
+  return useQuery({
     queryKey: [QUERY_KEYS.ROOM_CATEGORY_DETAIL, roomId, categoryId],
     queryFn: async () => await getRoomCategoryDetail({ roomId, categoryId }),
     staleTime: STALE_TIME,

--- a/frontend/src/hooks/query/useGetUserQuery.ts
+++ b/frontend/src/hooks/query/useGetUserQuery.ts
@@ -2,10 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getUserInfo } from '@/apis/user';
 import { QUERY_KEYS } from '@/constants/queryKeys';
-import { User } from '@/types/user';
 
 const useGetUserQuery = () => {
-  return useQuery<User>({
+  return useQuery({
     queryKey: [QUERY_KEYS.AUTH, QUERY_KEYS.USER],
     queryFn: getUserInfo,
     retry: false,

--- a/frontend/src/hooks/query/usePostCustomQuestionMutation.ts
+++ b/frontend/src/hooks/query/usePostCustomQuestionMutation.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+
+import fetcher from '@/apis/fetcher';
+import { BASE_URL } from '@/apis/url';
+
+export interface RequestParamPostCustomQuestion {
+  categoryId: number;
+  title: string;
+  subtitle?: string;
+}
+const postCustomQuestion = (question: RequestParamPostCustomQuestion) => {
+  return fetcher.post({
+    url: `${BASE_URL}/questions`,
+    body: question,
+  });
+};
+
+const usePostCustomQuestionMutation = () => {
+  return useMutation({
+    mutationFn: postCustomQuestion,
+  });
+};
+
+export default usePostCustomQuestionMutation;

--- a/frontend/src/hooks/query/usePostCustomQuestionMutation.ts
+++ b/frontend/src/hooks/query/usePostCustomQuestionMutation.ts
@@ -2,6 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 
 import fetcher from '@/apis/fetcher';
 import { BASE_URL } from '@/apis/url';
+import { queryClient } from '@/App';
+import { QUERY_KEYS } from '@/constants/queryKeys';
 
 export interface RequestParamPostCustomQuestion {
   categoryId: number;
@@ -18,6 +20,9 @@ const postCustomQuestion = (question: RequestParamPostCustomQuestion) => {
 const usePostCustomQuestionMutation = () => {
   return useMutation({
     mutationFn: postCustomQuestion,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.CHECKLIST_ALL_QUESTIONS] });
+    },
   });
 };
 

--- a/frontend/src/pages/ChecklistQuestionSelectPage.tsx
+++ b/frontend/src/pages/ChecklistQuestionSelectPage.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
+import { useStore } from 'zustand';
 
 import Button from '@/components/_common/Button/Button';
 import ListErrorFallback from '@/components/_common/errorBoundary/ListErrorFallback';
@@ -10,6 +11,7 @@ import { TabProvider } from '@/components/_common/Tabs/TabContext';
 import TipBox from '@/components/_common/TipBox/TipBox';
 import { ChecklistQuestionSelectTabs } from '@/components/ChecklistQuestionSelect/ChecklistQuestionSelectTabs';
 import QuestionCustomListTemplate from '@/components/ChecklistQuestionSelect/CustomQuestions/QuestionCustomListTemplate';
+import { selectedIdsStore } from '@/components/ChecklistQuestionSelect/CustomQuestions/selectedQuestionIdsStore';
 import QuestionListTemplate from '@/components/ChecklistQuestionSelect/QuestionListTemplate/QuestionListTemplate';
 import { TOAST_MESSAGE } from '@/constants/messages/message';
 import { ROUTE_PATH } from '@/constants/routePath';
@@ -29,6 +31,7 @@ const ChecklistQuestionSelectPage = () => {
   const { mutate: putCustomChecklist } = usePutCustomChecklist();
   const { selectedQuestions, setValidCategory } = useChecklistQuestionSelectStore();
   const { resetShowTip } = useHandleTip('CUSTOM_QUESTION');
+  const { selectedIds: customSelectedIds } = useStore(selectedIdsStore);
 
   const handleSubmitChecklist = () => {
     if (!selectedQuestions.length) {
@@ -36,7 +39,7 @@ const ChecklistQuestionSelectPage = () => {
       return;
     }
 
-    putCustomChecklist([...selectedQuestions], {
+    putCustomChecklist([...selectedQuestions, ...customSelectedIds], {
       onSuccess: () => {
         showToast({ message: TOAST_MESSAGE.CUSTOM });
         navigate(ROUTE_PATH.checklistList);

--- a/frontend/src/pages/ChecklistQuestionSelectPage.tsx
+++ b/frontend/src/pages/ChecklistQuestionSelectPage.tsx
@@ -9,6 +9,7 @@ import Layout from '@/components/_common/layout/Layout';
 import { TabProvider } from '@/components/_common/Tabs/TabContext';
 import TipBox from '@/components/_common/TipBox/TipBox';
 import { ChecklistQuestionSelectTabs } from '@/components/ChecklistQuestionSelect/ChecklistQuestionSelectTabs';
+import QuestionCustomListTemplate from '@/components/ChecklistQuestionSelect/CustomQuestions/QuestionCustomListTemplate';
 import QuestionListTemplate from '@/components/ChecklistQuestionSelect/QuestionListTemplate/QuestionListTemplate';
 import { TOAST_MESSAGE } from '@/constants/messages/message';
 import { ROUTE_PATH } from '@/constants/routePath';
@@ -35,7 +36,7 @@ const ChecklistQuestionSelectPage = () => {
       return;
     }
 
-    putCustomChecklist(selectedQuestions, {
+    putCustomChecklist([...selectedQuestions], {
       onSuccess: () => {
         showToast({ message: TOAST_MESSAGE.CUSTOM });
         navigate(ROUTE_PATH.checklistList);
@@ -81,9 +82,9 @@ const ChecklistQuestionSelectPage = () => {
           <ErrorBoundary FallbackComponent={ListErrorFallback}>
             <Suspense>
               <QuestionListTemplate />
+              <QuestionCustomListTemplate />
             </Suspense>
           </ErrorBoundary>
-          {/* <CustomChecklistQuestionSection /> TODO: 다시 추가하기 */}
         </Layout>
       </TabProvider>
     </>

--- a/frontend/src/store/roomInfoStore.ts
+++ b/frontend/src/store/roomInfoStore.ts
@@ -108,7 +108,7 @@ export const roomInfoStore = createStore<RoomInfoState & { actions: RoomInfoActi
   ),
 );
 
-export const roomInfoApiMapper = (values: Partial<RoomInfoStoreState>) => {
+export const roomInfoApiPostMapper = (values: Partial<RoomInfoStoreState>) => {
   const result = {
     ...values,
     structure: values.structure === '' ? undefined : values.structure,

--- a/frontend/src/store/roomInfoStore.ts
+++ b/frontend/src/store/roomInfoStore.ts
@@ -121,9 +121,13 @@ export const roomInfoApiPostMapper = (values: Partial<RoomInfoStoreState>) => {
     size: values.size === 0 ? undefined : values.size,
     contractTerm: values.contractTerm === 0 ? undefined : values.contractTerm,
     occupancyMonth: values.occupancyMonth === 0 ? undefined : values.occupancyMonth,
+
+    station: undefined,
+    walkingTime: undefined,
+    address: values.address === '' ? undefined : values.address,
   };
 
-  const { station: _, ...resultToSubmit } = result;
+  const { ...resultToSubmit } = result;
 
   return mapObjUndefinedToNull(resultToSubmit) as Nullable<Partial<RoomInfoStoreState>>;
 };

--- a/frontend/src/types/checklist.ts
+++ b/frontend/src/types/checklist.ts
@@ -46,19 +46,12 @@ export interface ChecklistQuestionWithIsSelected extends ChecklistQuestion {
 }
 
 // 체크리스트 카드
-export interface ChecklistPreview {
+export type ChecklistPreview = Pick<RoomInfo, 'address' | 'deposit' | 'rent' | 'createdAt' | 'summary' | 'roomName'> & {
   checklistId: number;
-  roomName: string;
-  address: string;
-  deposit: number;
-  rent: number;
-  station?: SubwayStation;
-  createdAt: string;
-  summary: string;
   isLiked: boolean;
-  // TODO: 새로운 기능으로 추가된 썸네일 사진 작업 - 백엔드와 이름 논의 필요
-  thumbnail?: string;
-}
+  station?: SubwayStation;
+  thumbnail?: string; // TODO: 새로운 기능으로 추가된 썸네일 사진 작업 - 백엔드와 이름 논의 필요
+};
 
 // 체크리스트 디테일
 export interface ChecklistInfo {

--- a/frontend/src/types/room.ts
+++ b/frontend/src/types/room.ts
@@ -29,4 +29,6 @@ export type RoomInfo = Partial<
   } & Position
 >;
 
+export type RoomInfoApiRes = Omit<RoomInfo, 'roomName'> & { checklistName: string };
+
 export type RoomInfoName = keyof RoomInfo;


### PR DESCRIPTION
## ❗ Issue

- #1216

## ✨ 구현한 기능

커스텀 질문 선택, 추가 기능 구현

커스텀 질문 추가 모달
<img height="300" alt="image" src="https://github.com/user-attachments/assets/938c78d9-8411-4097-bdf1-54302621a13a" />

추가된 질문이 표시됩니다.
<img  height="260" alt="image" src="https://github.com/user-attachments/assets/3f191b99-7816-4539-9209-8899062653b9" />

+로 선택후 저장버튼을 누르면 재접속 시 유지되며,

선택한 커스텀질문만 방 기록 시 등장
<img height="300" alt="image" src="https://github.com/user-attachments/assets/d3d5c2da-5598-484c-baa3-14cd34e27207" />




## 📢 논의하고 싶은 내용



## 🎸 기타

